### PR TITLE
 fix: remove unnecessary manual encoding of parameter

### DIFF
--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/NeteaseAPI.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/NeteaseAPI.kt
@@ -45,13 +45,9 @@ class NeteaseAPI {
      */
     @OptIn(ExperimentalSerializationApi::class)
     suspend fun getSongInfo(query: SongInfo, offset: Int? = 0): SongInfo? {
-        val search = withContext(Dispatchers.IO) {
-            URLEncoder.encode(
-                "${query.songName} ${query.artistName}",
-                Charsets.UTF_8.toString()
-            )
-        }
-        if (search == "+")
+        val search = "${query.songName} ${query.artistName}"
+
+        if (search == " ")
             throw EmptyQueryException()
 
         val response = client.get(


### PR DESCRIPTION
The HttpClient seems to handle escaping internally. Manual escaping (in the NetEase API part) may lead to duplicate escaping and cause unexpected results if there are special characters in the song name or artist name.