### PR TITLE
Add Musixmatch API Integration

### DIFF
--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
@@ -3,6 +3,7 @@ package pl.lambada.songsync.data.remote.lyrics_providers
 import android.util.Log
 import pl.lambada.songsync.data.remote.lyrics_providers.others.AppleAPI
 import pl.lambada.songsync.data.remote.lyrics_providers.others.LRCLibAPI
+import pl.lambada.songsync.data.remote.lyrics_providers.others.MusixmatchAPI
 import pl.lambada.songsync.data.remote.lyrics_providers.others.NeteaseAPI
 import pl.lambada.songsync.data.remote.lyrics_providers.spotify.SpotifyAPI
 import pl.lambada.songsync.data.remote.lyrics_providers.spotify.SpotifyLyricsAPI
@@ -29,6 +30,9 @@ class LyricsProviderService {
 
     // Apple Track ID
     private var appleID = 0L
+
+    // Musixmatch Track ID
+    private var musixmatchID = 0L
     // TODO: Use values from SongInfo object returned by search instead of storing them here
 
     /**
@@ -66,7 +70,7 @@ class LyricsProviderService {
 
                 // TODO
                 Providers.MUSIXMATCH -> AppleAPI().getSongInfo(query).also {
-                    appleID = it?.appleID ?: 0
+                    musixmatchID = it?.appleID ?: 0
                 } ?: throw NoTrackFoundException()
             }
         } catch (e: InternalErrorException) {
@@ -107,7 +111,7 @@ class LyricsProviderService {
                 )
                 // TODO
                 Providers.MUSIXMATCH -> AppleAPI().getSyncedLyrics(
-                    appleID,
+                    musixmatchID,
                     multiPersonWordByWord
                 )
             }

--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
@@ -68,9 +68,8 @@ class LyricsProviderService {
                     appleID = it?.appleID ?: 0
                 } ?: throw NoTrackFoundException()
 
-                // TODO
-                Providers.MUSIXMATCH -> AppleAPI().getSongInfo(query).also {
-                    musixmatchID = it?.appleID ?: 0
+                Providers.MUSIXMATCH -> MusixmatchAPI().getSongInfo(query).also {
+                    musixmatchID = it?.musixmatchID ?: 0
                 } ?: throw NoTrackFoundException()
             }
         } catch (e: InternalErrorException) {
@@ -109,11 +108,7 @@ class LyricsProviderService {
                     appleID,
                     multiPersonWordByWord
                 )
-                // TODO
-                Providers.MUSIXMATCH -> AppleAPI().getSyncedLyrics(
-                    musixmatchID,
-                    multiPersonWordByWord
-                )
+                Providers.MUSIXMATCH -> MusixmatchAPI().getSyncedLyrics(musixmatchID)
             }
         } catch (e: Exception) {
             null

--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
@@ -63,6 +63,11 @@ class LyricsProviderService {
                 Providers.APPLE -> AppleAPI().getSongInfo(query).also {
                     appleID = it?.appleID ?: 0
                 } ?: throw NoTrackFoundException()
+
+                // TODO
+                Providers.MUSIXMATCH -> AppleAPI().getSongInfo(query).also {
+                    appleID = it?.appleID ?: 0
+                } ?: throw NoTrackFoundException()
             }
         } catch (e: InternalErrorException) {
             throw e
@@ -97,6 +102,11 @@ class LyricsProviderService {
                     includeTranslationNetEase
                 )
                 Providers.APPLE -> AppleAPI().getSyncedLyrics(
+                    appleID,
+                    multiPersonWordByWord
+                )
+                // TODO
+                Providers.MUSIXMATCH -> AppleAPI().getSyncedLyrics(
                     appleID,
                     multiPersonWordByWord
                 )

--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
@@ -1,0 +1,72 @@
+package pl.lambada.songsync.data.remote.lyrics_providers.others
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import pl.lambada.songsync.domain.model.SongInfo
+import pl.lambada.songsync.domain.model.lyrics_providers.others.MusixmatchLyricsResponse
+import pl.lambada.songsync.domain.model.lyrics_providers.others.MusixmatchSearchResponse
+import pl.lambada.songsync.util.EmptyQueryException
+import pl.lambada.songsync.util.networking.Ktor.client
+import pl.lambada.songsync.util.networking.Ktor.json
+import java.net.URLEncoder
+
+class MusixmatchAPI {
+    private val baseURL = "https://kerollosy.alwaysdata.net"
+
+    /**
+     * Searches for synced lyrics using the song name and artist name.
+     * @param query The SongInfo object with songName and artistName fields filled.
+     * @return Search result as a SongInfo object.
+     */
+    suspend fun getSongInfo(query: SongInfo): SongInfo? {
+        val search = withContext(Dispatchers.IO) {
+            URLEncoder.encode(
+                "${query.songName} ${query.artistName}",
+                Charsets.UTF_8.toString()
+            )
+        }
+
+        if (search == " ")
+            throw EmptyQueryException()
+
+        val response = client.get(
+            "$baseURL/search?q=$search"
+        )
+        val responseBody = response.bodyAsText(Charsets.UTF_8)
+
+        if (response.status.value !in 200..299 || responseBody == "[]")
+            return null
+
+        val json = json.decodeFromString<List<MusixmatchSearchResponse>>(responseBody)
+
+        val result = json[0]
+
+        return SongInfo(
+            songName = result.track_name,
+            artistName = result.artist_name,
+            songLink = result.track_share_url,
+            albumCoverLink = result.album_cover,
+            musixmatchID = result.commontrack_id,
+        )
+    }
+
+    /**
+     * Searches for synced lyrics using the song name and artist name.
+     * @param id The ID of the song from search results.
+     * @return The synced lyrics as a string.
+     */
+    suspend fun getSyncedLyrics(id: Long): String? {
+        val response = client.get(
+            "$baseURL/lyrics?id=$id"
+        )
+        val responseBody = response.bodyAsText(Charsets.UTF_8)
+
+        if (response.status.value !in 200..299)
+            return null
+
+        val json = json.decodeFromString<MusixmatchLyricsResponse>(responseBody)
+        return json.subtitle_body
+    }
+}

--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
@@ -44,11 +44,11 @@ class MusixmatchAPI {
         val result = json[0]
 
         return SongInfo(
-            songName = result.track_name,
-            artistName = result.artist_name,
-            songLink = result.track_share_url,
-            albumCoverLink = result.album_cover,
-            musixmatchID = result.commontrack_id,
+            songName = result.songName,
+            artistName = result.artistName,
+            songLink = result.url,
+            albumCoverLink = result.artwork,
+            musixmatchID = result.id,
         )
     }
 
@@ -67,6 +67,6 @@ class MusixmatchAPI {
             return null
 
         val json = json.decodeFromString<MusixmatchLyricsResponse>(responseBody)
-        return json.subtitle_body
+        return json.lyrics
     }
 }

--- a/app/src/main/java/pl/lambada/songsync/domain/model/SongInfo.kt
+++ b/app/src/main/java/pl/lambada/songsync/domain/model/SongInfo.kt
@@ -22,4 +22,5 @@ data class SongInfo(
     var lrcLibID: Int? = null, // LRCLib-only
     var neteaseID: Long? = null, // Netease-only
     var appleID: Long? = null, // Apple-only
+    var musixmatchID: Long? = null, // Musixmatch-only
 ) : Parcelable

--- a/app/src/main/java/pl/lambada/songsync/domain/model/lyrics_providers/others/Musixmatch.kt
+++ b/app/src/main/java/pl/lambada/songsync/domain/model/lyrics_providers/others/Musixmatch.kt
@@ -4,23 +4,23 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class MusixmatchSearchResponse(
-    val commontrack_id: Long,
-    val track_name: String,
-    val artist_name: String,
-    val album_name: String,
-    val album_cover: String,
-    val release_date: String,
-    val track_length: Int,
-    val track_share_url: String,
-    val album_id: Long,
-    val has_lyrics: Boolean
+    val id: Long,
+    val songName: String,
+    val artistName: String,
+    val albumName: String,
+    val artwork: String,
+    val releaseDate: String,
+    val duration: Int,
+    val url: String,
+    val albumId: Long,
+    val hasLyrics: Boolean
 )
 
 @Serializable
 data class MusixmatchLyricsResponse(
-    val subtitle_id: Long,
-    val subtitle_length: Int,
-    val subtitle_language: String,
-    val updated_time: String,
-    val subtitle_body: String,
+    val id: Long,
+    val duration: Int,
+    val language: String,
+    val updatedTime: String,
+    val lyrics: String,
 )

--- a/app/src/main/java/pl/lambada/songsync/domain/model/lyrics_providers/others/Musixmatch.kt
+++ b/app/src/main/java/pl/lambada/songsync/domain/model/lyrics_providers/others/Musixmatch.kt
@@ -13,7 +13,8 @@ data class MusixmatchSearchResponse(
     val duration: Int,
     val url: String,
     val albumId: Long,
-    val hasLyrics: Boolean
+    val hasSyncedLyrics: Boolean,
+    val hasUnsyncedLyrics: Boolean
 )
 
 @Serializable

--- a/app/src/main/java/pl/lambada/songsync/domain/model/lyrics_providers/others/Musixmatch.kt
+++ b/app/src/main/java/pl/lambada/songsync/domain/model/lyrics_providers/others/Musixmatch.kt
@@ -12,7 +12,7 @@ data class MusixmatchSearchResponse(
     val release_date: String,
     val track_length: Int,
     val track_share_url: String,
-    val album_id: String,
+    val album_id: Long,
     val has_lyrics: Boolean
 )
 

--- a/app/src/main/java/pl/lambada/songsync/domain/model/lyrics_providers/others/Musixmatch.kt
+++ b/app/src/main/java/pl/lambada/songsync/domain/model/lyrics_providers/others/Musixmatch.kt
@@ -1,0 +1,26 @@
+package pl.lambada.songsync.domain.model.lyrics_providers.others
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MusixmatchSearchResponse(
+    val commontrack_id: Long,
+    val track_name: String,
+    val artist_name: String,
+    val album_name: String,
+    val album_cover: String,
+    val release_date: String,
+    val track_length: Int,
+    val track_share_url: String,
+    val album_id: String,
+    val has_lyrics: Boolean
+)
+
+@Serializable
+data class MusixmatchLyricsResponse(
+    val subtitle_id: Long,
+    val subtitle_length: Int,
+    val subtitle_language: String,
+    val updated_time: String,
+    val subtitle_body: String,
+)

--- a/app/src/main/java/pl/lambada/songsync/util/LyricsUtils.kt
+++ b/app/src/main/java/pl/lambada/songsync/util/LyricsUtils.kt
@@ -164,7 +164,8 @@ enum class Providers(val displayName: String) {
     SPOTIFY("Spotify (via SpotifyLyricsAPI)"),
     LRCLIB("LRCLib"),
     NETEASE("Netease") { val inf = 0},
-    APPLE("Apple Music")
+    APPLE("Apple Music"),
+    MUSIXMATCH("Musixmatch")
 }
 
 // only for invoking the task and handling and reporting progress


### PR DESCRIPTION
This PR adds support for Musixmatch as a lyrics provider, allowing synced lyrics to be retrieved from the Musixmatch API.

Musixmatch is the best lyrics provider afaik
I implemented my own server to filter the Musixmatch output, ensuring compatibility with SongSync's format

###### I learned kotlin just to make this PR