### PR TITLE
feat: Added Quick Lyrics Search Activity

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -3,15 +3,19 @@
     <option name="myName" value="Project Default" />
     <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
@@ -35,6 +39,7 @@
     </inspection_tool>
     <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -5,8 +5,12 @@
       <set>
         <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
         <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
         <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
         <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
       </set>
     </option>
   </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,13 +8,13 @@ plugins {
 
 android {
     namespace = "pl.lambada.songsync"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "pl.lambada.songsync"
         minSdk = 21
         //noinspection OldTargetApi
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 421
         versionName = "4.2.1"
 
@@ -89,6 +89,6 @@ dependencies {
     implementation(libs.ktor.cio)
     implementation(libs.taglib)
     implementation(libs.datastore.preferences)
-    debugImplementation(libs.ui.tooling)
-    debugImplementation(libs.ui.tooling.preview)
+    implementation(libs.ui.tooling) //NOT RECOMMENDED
+    implementation(libs.ui.tooling.preview) //NOT RECOMMENDED
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,22 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".activities.quicksearch.QuickLyricsSearchActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:launchMode="singleInstance"
+            android:theme="@style/Theme.SongSync.SharingActivity"
+            android:label="Quick Lyrics Search">
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchActivity.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchActivity.kt
@@ -2,6 +2,7 @@ package pl.lambada.songsync.activities.quicksearch
 
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -15,6 +16,7 @@ import coil.ImageLoader
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
 import kotlinx.coroutines.Dispatchers
+import pl.lambada.songsync.R
 import pl.lambada.songsync.activities.quicksearch.viewmodel.QuickLyricsSearchViewModel
 import pl.lambada.songsync.activities.quicksearch.viewmodel.QuickLyricsSearchViewModelFactory
 import pl.lambada.songsync.data.UserSettingsController
@@ -54,7 +56,6 @@ class QuickLyricsSearchActivity : AppCompatActivity() {
             .dispatcher(Dispatchers.IO)
             .build()
 
-
         enableEdgeToEdge()
         handleShareIntent(intent)
 
@@ -65,7 +66,7 @@ class QuickLyricsSearchActivity : AppCompatActivity() {
                 ModalBottomSheet(
                     sheetState = sheetState,
                     properties = ModalBottomSheetDefaults.properties,
-                    onDismissRequest = { this.finish() }
+                    onDismissRequest = { finish() }
                 ) {
                     QuickLyricsSearchPage(
                         state = viewModelState,
@@ -89,14 +90,24 @@ class QuickLyricsSearchActivity : AppCompatActivity() {
         when (intent.action) {
             Intent.ACTION_SEND -> {
                 val songName =
-                    intent.getStringExtra("songName") ?: "" //TODO: Change to a exception in the VM
+                    intent.getStringExtra("songName")
                 val artistName = intent.getStringExtra("artistName")
-                    ?: "" //TODO: Change to a exception in the VM
+                    ?: "" // Artist name is optional. This may be misleading sometimes.
+
+                if (songName.isNullOrBlank()) {
+                    Toast.makeText(
+                        this,
+                        this.getString(R.string.song_name_not_provided),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    finish()
+                    return
+                }
 
                 viewModel.onEvent(
                     QuickLyricsSearchViewModel.Event.Fetch(
-                        songName to artistName,
-                        this
+                        song = songName to artistName,
+                        context = this
                     )
                 )
             }

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchActivity.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchActivity.kt
@@ -37,35 +37,6 @@ class QuickLyricsSearchActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         enableEdgeToEdge()
-
-        // Disable the default system window insets handling
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-
-        // Set a listener to handle window insets manually
-        ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { v, insets ->
-            // Remove any padding from the view
-            v.setPadding(0, 0, 0, 0)
-            insets
-        }
-
-        // Configure the window properties
-        window.run {
-            // Set the background to be transparent
-            setBackgroundDrawable(ColorDrawable(0))
-            // Set the window layout to match the parent dimensions
-            setLayout(
-                WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT
-            )
-            // Set the window type based on the Android version
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                // For Android O and above, use TYPE_APPLICATION_OVERLAY
-                setType(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY)
-            } else {
-                // For older versions, use TYPE_SYSTEM_ALERT
-                setType(WindowManager.LayoutParams.TYPE_SYSTEM_ALERT)
-            }
-        }
-
         handleShareIntent(intent)
 
         setContent {

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchActivity.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchActivity.kt
@@ -25,18 +25,17 @@ import pl.lambada.songsync.ui.theme.SongSyncTheme
 import pl.lambada.songsync.util.dataStore
 
 class QuickLyricsSearchActivity : AppCompatActivity() {
-
-    val userSettingsController = UserSettingsController(dataStore)
     private val lyricsProviderService = LyricsProviderService()
 
-    private val viewModel: QuickLyricsSearchViewModel by viewModels {
-        QuickLyricsSearchViewModelFactory(userSettingsController, lyricsProviderService)
-    }
 
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val userSettingsController = UserSettingsController(dataStore)
+        val viewModel: QuickLyricsSearchViewModel by viewModels {
+            QuickLyricsSearchViewModelFactory(userSettingsController, lyricsProviderService)
+        }
         activityImageLoader = ImageLoader.Builder(this)
             .memoryCache {
                 MemoryCache.Builder(this)
@@ -57,7 +56,7 @@ class QuickLyricsSearchActivity : AppCompatActivity() {
             .build()
 
         enableEdgeToEdge()
-        handleShareIntent(intent)
+        handleShareIntent(intent, sendEvent = viewModel::onEvent)
 
         setContent {
             val sheetState = rememberModalBottomSheetState()
@@ -86,7 +85,10 @@ class QuickLyricsSearchActivity : AppCompatActivity() {
     }
 
 
-    private fun handleShareIntent(intent: Intent) {
+    private fun handleShareIntent(
+        intent: Intent,
+        sendEvent: (QuickLyricsSearchViewModel.Event) -> Unit
+    ) {
         when (intent.action) {
             Intent.ACTION_SEND -> {
                 val songName =
@@ -104,7 +106,7 @@ class QuickLyricsSearchActivity : AppCompatActivity() {
                     return
                 }
 
-                viewModel.onEvent(
+                sendEvent(
                     QuickLyricsSearchViewModel.Event.Fetch(
                         song = songName to artistName,
                         context = this
@@ -116,5 +118,6 @@ class QuickLyricsSearchActivity : AppCompatActivity() {
 
     companion object {
         lateinit var activityImageLoader: ImageLoader
+        lateinit var userSettingsController: UserSettingsController
     }
 }

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchActivity.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchActivity.kt
@@ -1,11 +1,7 @@
 package pl.lambada.songsync.activities.quicksearch
 
 import android.content.Intent
-import android.graphics.drawable.ColorDrawable
-import android.os.Build
 import android.os.Bundle
-import android.view.WindowManager
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -14,13 +10,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.ImageLoader
-import coil.ImageLoaderFactory
 import coil.disk.DiskCache
-import coil.imageLoader
 import coil.memory.MemoryCache
 import kotlinx.coroutines.Dispatchers
 import pl.lambada.songsync.activities.quicksearch.viewmodel.QuickLyricsSearchViewModel
@@ -96,10 +88,17 @@ class QuickLyricsSearchActivity : AppCompatActivity() {
     private fun handleShareIntent(intent: Intent) {
         when (intent.action) {
             Intent.ACTION_SEND -> {
-                val songName = intent.getStringExtra("songName") ?: "" //TODO: Change to a exception in the VM
-                val artistName = intent.getStringExtra("artistName") ?: "" //TODO: Change to a exception in the VM
+                val songName =
+                    intent.getStringExtra("songName") ?: "" //TODO: Change to a exception in the VM
+                val artistName = intent.getStringExtra("artistName")
+                    ?: "" //TODO: Change to a exception in the VM
 
-                viewModel.onEvent(QuickLyricsSearchViewModel.Event.Fetch(songName to artistName, this))
+                viewModel.onEvent(
+                    QuickLyricsSearchViewModel.Event.Fetch(
+                        songName to artistName,
+                        this
+                    )
+                )
             }
         }
     }

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchActivity.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchActivity.kt
@@ -1,0 +1,108 @@
+package pl.lambada.songsync.activities.quicksearch
+
+import android.content.Intent
+import android.graphics.drawable.ColorDrawable
+import android.os.Build
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import pl.lambada.songsync.activities.quicksearch.viewmodel.QuickLyricsSearchViewModel
+import pl.lambada.songsync.activities.quicksearch.viewmodel.QuickLyricsSearchViewModelFactory
+import pl.lambada.songsync.data.UserSettingsController
+import pl.lambada.songsync.data.remote.lyrics_providers.LyricsProviderService
+import pl.lambada.songsync.ui.theme.SongSyncTheme
+import pl.lambada.songsync.util.dataStore
+
+class QuickLyricsSearchActivity : ComponentActivity() {
+
+    val userSettingsController = UserSettingsController(dataStore)
+    private val lyricsProviderService = LyricsProviderService()
+
+    private val viewModel: QuickLyricsSearchViewModel by viewModels {
+        QuickLyricsSearchViewModelFactory(userSettingsController, lyricsProviderService)
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        enableEdgeToEdge()
+
+        // Disable the default system window insets handling
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        // Set a listener to handle window insets manually
+        ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { v, insets ->
+            // Remove any padding from the view
+            v.setPadding(0, 0, 0, 0)
+            insets
+        }
+
+        // Configure the window properties
+        window.run {
+            // Set the background to be transparent
+            setBackgroundDrawable(ColorDrawable(0))
+            // Set the window layout to match the parent dimensions
+            setLayout(
+                WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT
+            )
+            // Set the window type based on the Android version
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                // For Android O and above, use TYPE_APPLICATION_OVERLAY
+                setType(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY)
+            } else {
+                // For older versions, use TYPE_SYSTEM_ALERT
+                setType(WindowManager.LayoutParams.TYPE_SYSTEM_ALERT)
+            }
+        }
+
+        handleShareIntent(intent)
+
+        setContent {
+            val sheetState = rememberModalBottomSheetState()
+            val viewModelState = viewModel.state.collectAsStateWithLifecycle()
+            SongSyncTheme(pureBlack = userSettingsController.pureBlack) {
+                ModalBottomSheet(
+                    sheetState = sheetState,
+                    properties = ModalBottomSheetDefaults.properties,
+                    onDismissRequest = { this.finish() }
+                ) {
+                    QuickLyricsSearchPage(
+                        state = viewModelState,
+                        onSendLyrics = { lyrics ->
+                            val resultIntent = Intent().apply {
+                                action = Intent.ACTION_SEND
+                                putExtra("lyrics", lyrics)
+                                type = "text/plain"
+                            }
+                            setResult(RESULT_OK, resultIntent)
+                            finish()
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+
+    private fun handleShareIntent(intent: Intent) {
+        when (intent.action) {
+            Intent.ACTION_SEND -> {
+                val songName = intent.getStringExtra("songName") ?: "" //TODO: Change to a exception in the VM
+                val artistName = intent.getStringExtra("artistName") ?: "" //TODO: Change to a exception in the VM
+
+                viewModel.onEvent(QuickLyricsSearchViewModel.Event.Fetch(songName to artistName, this))
+            }
+        }
+    }
+}

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
@@ -1,0 +1,72 @@
+package pl.lambada.songsync.activities.quicksearch
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import pl.lambada.songsync.activities.quicksearch.viewmodel.QuickLyricsSearchViewModel
+import pl.lambada.songsync.util.ResourceState
+import pl.lambada.songsync.util.ScreenState
+
+@Composable
+fun QuickLyricsSearchPage(
+    state: State<QuickLyricsSearchViewModel.QuickSearchViewState>,
+    onSendLyrics: (String) -> Unit
+) {
+    Crossfade(state.value.screenState) { pageState ->
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text("Search query: ${state.value.song}")
+            when(pageState) {
+                is ScreenState.Loading -> {
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                is ScreenState.Success -> {
+                    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Text("Success: ${pageState.data}")
+                        when(state.value.lyricsState) {
+                            is ResourceState.Loading<*> -> {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    CircularProgressIndicator()
+                                }
+                            }
+                            is ResourceState.Success<*> -> {
+                                state.value.lyricsState.data?.let { obtainedLyrics -> //This crunches the animation lol
+                                    Button(onClick = { onSendLyrics(obtainedLyrics) }) {
+                                        Text("Send lyrics back")
+                                    }
+                                    Text("Lyrics: $obtainedLyrics")
+                                }
+                            }
+                            is ResourceState.Error<*> -> {
+                                Text("Error: ${state.value.lyricsState.message}")
+                            }
+                        }
+                    }
+                }
+                is ScreenState.Error -> {
+                    Text("Error: ${pageState.exception.message}")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Send
 import androidx.compose.material.icons.filled.Cloud
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.rounded.Subtitles
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -242,14 +241,14 @@ private fun Heading(
                     modifier = Modifier.weight(1f),
                     onClick = { onSendLyrics(this.data ?: "") },
                     enabled = this is ResourceState.Success<*>,
-                    shape = RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)
+                    shape = RoundedCornerShape(8.dp) //RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)
                 )
-                ButtonWithIconAndText(
-                    icon = Icons.Filled.Settings,
-                    text = stringResource(R.string.settings),
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(topEnd = 8.dp, bottomEnd = 8.dp)
-                )
+//                ButtonWithIconAndText(
+//                    icon = Icons.Filled.Settings,
+//                    text = stringResource(R.string.settings),
+//                    modifier = Modifier.weight(1f),
+//                    shape = RoundedCornerShape(topEnd = 8.dp, bottomEnd = 8.dp)
+//                )
             }
         }
     }

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
@@ -48,154 +48,152 @@ fun QuickLyricsSearchPage(
             .padding(16.dp)
     ) {
         Crossfade(state.value.screenState) { pageState ->
-            Row {
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth()
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
-                        Column(
-                            modifier = Modifier.weight(1f),
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            Text(
-                                text = stringResource(R.string.showing_lyrics_for).uppercase(),
-                                style = MaterialTheme.typography.labelLarge.copy(
-                                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
-                                    letterSpacing = 2.sp
-                                )
+                        Text(
+                            text = stringResource(R.string.showing_lyrics_for).uppercase(),
+                            style = MaterialTheme.typography.labelLarge.copy(
+                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                                letterSpacing = 2.sp
                             )
+                        )
 
-                            state.value.song?.let { song ->
-                                Text(
-                                    text = song.first,
-                                    style = MaterialTheme.typography.headlineSmall
-                                )
-                                Text(
-                                    text = buildAnnotatedString {
-                                        append(stringResource(R.string.by))
-                                        append(" ")
-                                        withStyle(MaterialTheme.typography.titleMedium.toSpanStyle()) {
-                                            append(song.second)
-                                        }
-                                    },
-                                )
-                            }
-                        }
-                        Row(
-                            modifier = Modifier
-                                .weight(1f)
-                                .padding(8.dp),
-                            horizontalArrangement = Arrangement.SpaceEvenly,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            ButtonWithIconAndText(
-                                icon = Icons.AutoMirrored.Rounded.Send,
-                                text = stringResource(R.string.accept),
-                                modifier = Modifier
-                                    .weight(1f),
-                                onClick = { onSendLyrics(state.value.lyricsState.data!!) },
-                                enabled = state.value.lyricsState is ResourceState.Success,
-                                shape = RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)
+                        state.value.song?.let { song ->
+                            Text(
+                                text = song.first,
+                                style = MaterialTheme.typography.headlineSmall
                             )
-                            ButtonWithIconAndText(
-                                icon = Icons.Filled.Settings,
-                                text = stringResource(R.string.settings),
-                                modifier = Modifier
-                                    .weight(1f),
-                                shape = RoundedCornerShape(topEnd = 8.dp, bottomEnd = 8.dp)
+                            Text(
+                                text = buildAnnotatedString {
+                                    append(stringResource(R.string.by))
+                                    append(" ")
+                                    withStyle(MaterialTheme.typography.titleMedium.toSpanStyle()) {
+                                        append(song.second)
+                                    }
+                                },
                             )
                         }
                     }
+                    Row(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(8.dp),
+                        horizontalArrangement = Arrangement.SpaceEvenly,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        ButtonWithIconAndText(
+                            icon = Icons.AutoMirrored.Rounded.Send,
+                            text = stringResource(R.string.accept),
+                            modifier = Modifier
+                                .weight(1f),
+                            onClick = { onSendLyrics(state.value.lyricsState.data!!) },
+                            enabled = state.value.lyricsState is ResourceState.Success,
+                            shape = RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)
+                        )
+                        ButtonWithIconAndText(
+                            icon = Icons.Filled.Settings,
+                            text = stringResource(R.string.settings),
+                            modifier = Modifier
+                                .weight(1f),
+                            shape = RoundedCornerShape(topEnd = 8.dp, bottomEnd = 8.dp)
+                        )
+                    }
+                }
 
-                    HorizontalDivider()
+                HorizontalDivider()
 
-                    when (pageState) {
-                        is ScreenState.Loading -> {
-                            Box(
-                                modifier = Modifier.fillMaxWidth(),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                CircularProgressIndicator()
-                            }
+                when (pageState) {
+                    is ScreenState.Loading -> {
+                        Box(
+                            modifier = Modifier.fillMaxWidth(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
                         }
+                    }
 
-                        is ScreenState.Success -> {
-                            Column(
-                                modifier = Modifier.fillMaxWidth(),
-                                verticalArrangement = Arrangement.spacedBy(16.dp)
-                            ) {
-                                pageState.data?.let {
-                                    Column(
+                    is ScreenState.Success -> {
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalArrangement = Arrangement.spacedBy(16.dp)
+                        ) {
+                            pageState.data?.let {
+                                Column(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    Row(
                                         modifier = Modifier.fillMaxWidth(),
-                                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(6.dp)
                                     ) {
-                                        Row(
-                                            modifier = Modifier.fillMaxWidth(),
-                                            verticalAlignment = Alignment.CenterVertically,
-                                            horizontalArrangement = Arrangement.spacedBy(6.dp)
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.Filled.Cloud,
-                                                contentDescription = null,
+                                        Icon(
+                                            imageVector = Icons.Filled.Cloud,
+                                            contentDescription = null,
+                                        )
+                                        Text(
+                                            text = stringResource(R.string.cloud_song).uppercase(),
+                                            style = MaterialTheme.typography.bodyMedium.copy(
+                                                letterSpacing = 1.sp,
+                                                fontWeight = FontWeight.SemiBold
                                             )
-                                            Text(
-                                                text = stringResource(R.string.cloud_song).uppercase(),
-                                                style = MaterialTheme.typography.bodyMedium.copy(
-                                                    letterSpacing = 1.sp,
-                                                    fontWeight = FontWeight.SemiBold
-                                                )
-                                            )
-                                        }
-
-                                        QuickLyricsSongInfo(
-                                            songInfo = pageState.data,
-                                            modifier = Modifier.fillMaxWidth()
                                         )
                                     }
-                                    when (state.value.lyricsState) {
-                                        is ResourceState.Loading<*> -> {
-                                            Box(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                contentAlignment = Alignment.Center
-                                            ) {
-                                                CircularProgressIndicator()
-                                            }
-                                        }
 
-                                        is ResourceState.Success<*> -> {
-                                            state.value.lyricsState.data?.let { _ -> //This crunches the animation lol
-                                                ExpandableOutlinedCard(
-                                                    title = stringResource(R.string.song_lyrics),
-                                                    subtitle = stringResource(R.string.lyrics_subtitle),
-                                                    icon = Icons.Rounded.Subtitles,
-                                                    isExpanded = false,
-                                                    modifier = Modifier.fillMaxWidth()
-                                                ) {
-                                                    SyncedLyricsColumn(
-                                                        lyricsList = state.value.parsedLyrics,
-                                                        modifier = Modifier
-                                                            .fillMaxWidth()
-                                                            .padding(8.dp)
-                                                    )
-                                                }
-                                            }
-                                        }
-
-                                        is ResourceState.Error<*> -> {
-                                            Text("Error: ${state.value.lyricsState.message}")
+                                    QuickLyricsSongInfo(
+                                        songInfo = pageState.data,
+                                        modifier = Modifier.fillMaxWidth()
+                                    )
+                                }
+                                when (state.value.lyricsState) {
+                                    is ResourceState.Loading<*> -> {
+                                        Box(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            CircularProgressIndicator()
                                         }
                                     }
+
+                                    is ResourceState.Success<*> -> {
+                                        state.value.lyricsState.data?.let { _ -> //This crunches the animation lol
+                                            ExpandableOutlinedCard(
+                                                title = stringResource(R.string.song_lyrics),
+                                                subtitle = stringResource(R.string.lyrics_subtitle),
+                                                icon = Icons.Rounded.Subtitles,
+                                                isExpanded = false,
+                                                modifier = Modifier.fillMaxWidth()
+                                            ) {
+                                                SyncedLyricsColumn(
+                                                    lyricsList = state.value.parsedLyrics,
+                                                    modifier = Modifier
+                                                        .fillMaxWidth()
+                                                        .padding(8.dp)
+                                                )
+                                            }
+                                        }
+                                    }
+
+                                    is ResourceState.Error<*> -> {
+                                        Text("Error: ${state.value.lyricsState.message}")
+                                    }
                                 }
-
                             }
-                        }
 
-                        is ScreenState.Error -> {
-                            Text("Error: ${pageState.exception.message}")
                         }
+                    }
+
+                    is ScreenState.Error -> {
+                        Text("Error: ${pageState.exception.message}")
                     }
                 }
             }

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
@@ -1,70 +1,207 @@
 package pl.lambada.songsync.activities.quicksearch
 
+import android.util.Log
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.Send
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.rounded.Subtitles
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import pl.lambada.songsync.R
+import pl.lambada.songsync.activities.quicksearch.components.ButtonWithIconAndText
+import pl.lambada.songsync.activities.quicksearch.components.ExpandableOutlinedCard
+import pl.lambada.songsync.activities.quicksearch.components.QuickLyricsSongInfo
+import pl.lambada.songsync.activities.quicksearch.components.SyncedLyricsColumn
 import pl.lambada.songsync.activities.quicksearch.viewmodel.QuickLyricsSearchViewModel
 import pl.lambada.songsync.util.ResourceState
 import pl.lambada.songsync.util.ScreenState
+import pl.lambada.songsync.util.parseLyrics
 
 @Composable
 fun QuickLyricsSearchPage(
     state: State<QuickLyricsSearchViewModel.QuickSearchViewState>,
     onSendLyrics: (String) -> Unit
 ) {
-    Crossfade(state.value.screenState) { pageState ->
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Text("Search query: ${state.value.song}")
-            when(pageState) {
-                is ScreenState.Loading -> {
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.Center
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Crossfade(state.value.screenState) { pageState ->
+            Row {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth()
                     ) {
-                        CircularProgressIndicator()
-                    }
-                }
-                is ScreenState.Success -> {
-                    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                        Text("Success: ${pageState.data}")
-                        when(state.value.lyricsState) {
-                            is ResourceState.Loading<*> -> {
-                                Box(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    CircularProgressIndicator()
-                                }
-                            }
-                            is ResourceState.Success<*> -> {
-                                state.value.lyricsState.data?.let { obtainedLyrics -> //This crunches the animation lol
-                                    Button(onClick = { onSendLyrics(obtainedLyrics) }) {
-                                        Text("Send lyrics back")
-                                    }
-                                    Text("Lyrics: $obtainedLyrics")
-                                }
-                            }
-                            is ResourceState.Error<*> -> {
-                                Text("Error: ${state.value.lyricsState.message}")
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.showing_lyrics_for).uppercase(),
+                                style = MaterialTheme.typography.labelLarge.copy(
+                                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                                    letterSpacing = 2.sp
+                                )
+                            )
+
+                            state.value.song?.let { song ->
+                                Text(
+                                    text = song.first,
+                                    style = MaterialTheme.typography.headlineSmall
+                                )
+                                Text(
+                                    text = buildAnnotatedString {
+                                        append(stringResource(R.string.by))
+                                        append(" ")
+                                        withStyle(MaterialTheme.typography.titleMedium.toSpanStyle()) {
+                                            append(song.second)
+                                        }
+                                    },
+                                )
                             }
                         }
+                        Row(
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(8.dp),
+                            horizontalArrangement = Arrangement.SpaceEvenly,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            ButtonWithIconAndText(
+                                icon = Icons.AutoMirrored.Rounded.Send,
+                                text = stringResource(R.string.accept),
+                                modifier = Modifier
+                                    .weight(1f),
+                                onClick = { onSendLyrics(state.value.lyricsState.data!!) },
+                                enabled = state.value.lyricsState is ResourceState.Success,
+                                shape = RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)
+                            )
+                            ButtonWithIconAndText(
+                                icon = Icons.Filled.Settings,
+                                text = stringResource(R.string.settings),
+                                modifier = Modifier
+                                    .weight(1f),
+                                shape = RoundedCornerShape(topEnd = 8.dp, bottomEnd = 8.dp)
+                            )
+                        }
                     }
-                }
-                is ScreenState.Error -> {
-                    Text("Error: ${pageState.exception.message}")
+
+                    HorizontalDivider()
+
+                    when (pageState) {
+                        is ScreenState.Loading -> {
+                            Box(
+                                modifier = Modifier.fillMaxWidth(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                CircularProgressIndicator()
+                            }
+                        }
+
+                        is ScreenState.Success -> {
+                            Column(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalArrangement = Arrangement.spacedBy(16.dp)
+                            ) {
+                                pageState.data?.let {
+                                    Column(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                                    ) {
+                                        Row(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            horizontalArrangement = Arrangement.spacedBy(6.dp)
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Filled.Cloud,
+                                                contentDescription = null,
+                                            )
+                                            Text(
+                                                text = stringResource(R.string.cloud_song).uppercase(),
+                                                style = MaterialTheme.typography.bodyMedium.copy(
+                                                    letterSpacing = 1.sp,
+                                                    fontWeight = FontWeight.SemiBold
+                                                )
+                                            )
+                                        }
+
+                                        QuickLyricsSongInfo(
+                                            songInfo = pageState.data,
+                                            modifier = Modifier.fillMaxWidth()
+                                        )
+                                    }
+                                    when (state.value.lyricsState) {
+                                        is ResourceState.Loading<*> -> {
+                                            Box(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                contentAlignment = Alignment.Center
+                                            ) {
+                                                CircularProgressIndicator()
+                                            }
+                                        }
+
+                                        is ResourceState.Success<*> -> {
+                                            state.value.lyricsState.data?.let { _ -> //This crunches the animation lol
+                                                ExpandableOutlinedCard(
+                                                   title = stringResource(R.string.song_lyrics),
+                                                    subtitle = stringResource(R.string.lyrics_subtitle),
+                                                    icon = Icons.Rounded.Subtitles,
+                                                    isExpanded = false,
+                                                    modifier = Modifier.fillMaxWidth()
+                                                ) {
+                                                    SyncedLyricsColumn(
+                                                        lyricsList = state.value.parsedLyrics,
+                                                        modifier = Modifier.fillMaxWidth().padding(8.dp)
+                                                    )
+                                                }
+                                            }
+                                        }
+
+                                        is ResourceState.Error<*> -> {
+                                            Text("Error: ${state.value.lyricsState.message}")
+                                        }
+                                    }
+                                }
+
+                            }
+                        }
+
+                        is ScreenState.Error -> {
+                            Text("Error: ${pageState.exception.message}")
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
@@ -1,12 +1,15 @@
 package pl.lambada.songsync.activities.quicksearch
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Send
@@ -16,6 +19,7 @@ import androidx.compose.material.icons.rounded.Subtitles
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -34,6 +38,7 @@ import pl.lambada.songsync.activities.quicksearch.components.ExpandableOutlinedC
 import pl.lambada.songsync.activities.quicksearch.components.QuickLyricsSongInfo
 import pl.lambada.songsync.activities.quicksearch.components.SyncedLyricsColumn
 import pl.lambada.songsync.activities.quicksearch.viewmodel.QuickLyricsSearchViewModel
+import pl.lambada.songsync.ui.common.AnimatedCardContentTransformation
 import pl.lambada.songsync.util.ResourceState
 import pl.lambada.songsync.util.ScreenState
 
@@ -42,160 +47,198 @@ fun QuickLyricsSearchPage(
     state: State<QuickLyricsSearchViewModel.QuickSearchViewState>,
     onSendLyrics: (String) -> Unit
 ) {
+    val lyricsState = state.value.lyricsState
+    val parsedLyrics = state.value.parsedLyrics
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .padding(16.dp)
     ) {
         Crossfade(state.value.screenState) { pageState ->
-            Column(
+            LazyColumn(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
-                    ) {
-                        Text(
-                            text = stringResource(R.string.showing_lyrics_for).uppercase(),
-                            style = MaterialTheme.typography.labelLarge.copy(
-                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
-                                letterSpacing = 2.sp
-                            )
-                        )
-
-                        state.value.song?.let { song ->
-                            Text(
-                                text = song.first,
-                                style = MaterialTheme.typography.headlineSmall
-                            )
-                            Text(
-                                text = buildAnnotatedString {
-                                    append(stringResource(R.string.by))
-                                    append(" ")
-                                    withStyle(MaterialTheme.typography.titleMedium.toSpanStyle()) {
-                                        append(song.second)
-                                    }
-                                },
-                            )
-                        }
-                    }
-                    Row(
-                        modifier = Modifier
-                            .weight(1f)
-                            .padding(8.dp),
-                        horizontalArrangement = Arrangement.SpaceEvenly,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        ButtonWithIconAndText(
-                            icon = Icons.AutoMirrored.Rounded.Send,
-                            text = stringResource(R.string.accept),
-                            modifier = Modifier
-                                .weight(1f),
-                            onClick = { onSendLyrics(state.value.lyricsState.data!!) },
-                            enabled = state.value.lyricsState is ResourceState.Success,
-                            shape = RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)
-                        )
-                        ButtonWithIconAndText(
-                            icon = Icons.Filled.Settings,
-                            text = stringResource(R.string.settings),
-                            modifier = Modifier
-                                .weight(1f),
-                            shape = RoundedCornerShape(topEnd = 8.dp, bottomEnd = 8.dp)
+                state.value.song?.let { song ->
+                    item {
+                        Heading(
+                            song = song,
+                            lyricsState = lyricsState,
+                            onSendLyrics = onSendLyrics
                         )
                     }
                 }
 
-                HorizontalDivider()
+                item {
+                    HorizontalDivider()
+                }
 
-                when (pageState) {
-                    is ScreenState.Loading -> {
-                        Box(
-                            modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            CircularProgressIndicator()
-                        }
-                    }
+                item {
+                    AnimatedContent(
+                        modifier = Modifier.fillMaxWidth(),
+                        targetState = pageState
+                    ) { animatedPageState ->
+                        when (animatedPageState) {
+                            is ScreenState.Loading -> {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    CircularProgressIndicator()
+                                }
+                            }
 
-                    is ScreenState.Success -> {
-                        Column(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalArrangement = Arrangement.spacedBy(16.dp)
-                        ) {
-                            pageState.data?.let {
+                            is ScreenState.Success -> {
                                 Column(
                                     modifier = Modifier.fillMaxWidth(),
-                                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                                    verticalArrangement = Arrangement.spacedBy(16.dp)
                                 ) {
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(6.dp)
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Filled.Cloud,
-                                            contentDescription = null,
-                                        )
-                                        Text(
-                                            text = stringResource(R.string.cloud_song).uppercase(),
-                                            style = MaterialTheme.typography.bodyMedium.copy(
-                                                letterSpacing = 1.sp,
-                                                fontWeight = FontWeight.SemiBold
-                                            )
-                                        )
-                                    }
-
-                                    QuickLyricsSongInfo(
-                                        songInfo = pageState.data,
-                                        modifier = Modifier.fillMaxWidth()
-                                    )
-                                }
-                                when (state.value.lyricsState) {
-                                    is ResourceState.Loading<*> -> {
-                                        Box(
+                                    animatedPageState.data?.let {
+                                        Column(
                                             modifier = Modifier.fillMaxWidth(),
-                                            contentAlignment = Alignment.Center
+                                            verticalArrangement = Arrangement.spacedBy(4.dp)
                                         ) {
-                                            CircularProgressIndicator()
-                                        }
-                                    }
-
-                                    is ResourceState.Success<*> -> {
-                                        state.value.lyricsState.data?.let { _ -> //This crunches the animation lol
-                                            ExpandableOutlinedCard(
-                                                title = stringResource(R.string.song_lyrics),
-                                                subtitle = stringResource(R.string.lyrics_subtitle),
-                                                icon = Icons.Rounded.Subtitles,
-                                                isExpanded = false,
-                                                modifier = Modifier.fillMaxWidth()
+                                            Row(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                verticalAlignment = Alignment.CenterVertically,
+                                                horizontalArrangement = Arrangement.spacedBy(6.dp)
                                             ) {
-                                                SyncedLyricsColumn(
-                                                    lyricsList = state.value.parsedLyrics,
-                                                    modifier = Modifier
-                                                        .fillMaxWidth()
-                                                        .padding(8.dp)
+                                                Icon(
+                                                    imageVector = Icons.Filled.Cloud,
+                                                    contentDescription = null,
+                                                )
+                                                Text(
+                                                    text = stringResource(R.string.cloud_song).uppercase(),
+                                                    style = MaterialTheme.typography.bodyMedium.copy(
+                                                        letterSpacing = 1.sp,
+                                                        fontWeight = FontWeight.SemiBold
+                                                    )
                                                 )
                                             }
-                                        }
-                                    }
 
-                                    is ResourceState.Error<*> -> {
-                                        Text("Error: ${state.value.lyricsState.message}")
+                                            QuickLyricsSongInfo(
+                                                songInfo = animatedPageState.data,
+                                                modifier = Modifier.fillMaxWidth()
+                                            )
+                                        }
+
+                                        AnimatedContent(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            transitionSpec = { AnimatedCardContentTransformation },
+                                            targetState = state.value.lyricsState
+                                        ) { lyricsState ->
+                                            when (lyricsState) {
+                                                is ResourceState.Loading<*> -> {
+                                                    Box(
+                                                        modifier = Modifier.fillMaxWidth(),
+                                                        contentAlignment = Alignment.Center
+                                                    ) {
+                                                        LinearProgressIndicator(
+                                                            modifier = Modifier.fillMaxWidth(
+                                                                0.8f
+                                                            )
+                                                        )
+                                                    }
+                                                }
+
+                                                is ResourceState.Success<*> -> {
+                                                    lyricsState.data?.let { _ ->
+                                                        ExpandableOutlinedCard(
+                                                            title = stringResource(R.string.song_lyrics),
+                                                            subtitle = stringResource(R.string.lyrics_subtitle),
+                                                            icon = Icons.Rounded.Subtitles,
+                                                            isExpanded = false,
+                                                            modifier = Modifier.fillMaxWidth()
+                                                        ) {
+                                                            SyncedLyricsColumn(
+                                                                lyricsList = parsedLyrics,
+                                                                modifier = Modifier
+                                                                    .heightIn(
+                                                                        min = 200.dp,
+                                                                        max = 600.dp
+                                                                    )
+                                                                    .fillMaxWidth()
+                                                                    .padding(8.dp)
+                                                            )
+                                                        }
+                                                    }
+                                                }
+
+                                                is ResourceState.Error<*> -> {
+                                                    Text("Error: ${lyricsState.message}")
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
 
+                            is ScreenState.Error -> {
+                                Text("Error: ${animatedPageState.exception.message}")
+                            }
                         }
                     }
-
-                    is ScreenState.Error -> {
-                        Text("Error: ${pageState.exception.message}")
-                    }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Heading(
+    song: Pair<String, String>,
+    lyricsState: ResourceState<String>,
+    onSendLyrics: (String) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.showing_lyrics_for).uppercase(),
+                style = MaterialTheme.typography.labelLarge.copy(
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                    letterSpacing = 2.sp
+                )
+            )
+            Text(
+                text = song.first, style = MaterialTheme.typography.headlineSmall
+            )
+            Text(
+                text = buildAnnotatedString {
+                    append(stringResource(R.string.by))
+                    append(" ")
+                    withStyle(MaterialTheme.typography.titleMedium.toSpanStyle()) {
+                        append(song.second)
+                    }
+                },
+            )
+        }
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .padding(8.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            with(lyricsState) {
+                ButtonWithIconAndText(
+                    icon = Icons.AutoMirrored.Rounded.Send,
+                    text = stringResource(R.string.accept),
+                    modifier = Modifier.weight(1f),
+                    onClick = { onSendLyrics(this.data ?: "") },
+                    enabled = this is ResourceState.Success<*>,
+                    shape = RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)
+                )
+                ButtonWithIconAndText(
+                    icon = Icons.Filled.Settings,
+                    text = stringResource(R.string.settings),
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(topEnd = 8.dp, bottomEnd = 8.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import pl.lambada.songsync.R
 import pl.lambada.songsync.activities.quicksearch.components.ButtonWithIconAndText
+import pl.lambada.songsync.activities.quicksearch.components.ErrorCard
 import pl.lambada.songsync.activities.quicksearch.components.ExpandableOutlinedCard
 import pl.lambada.songsync.activities.quicksearch.components.QuickLyricsSongInfo
 import pl.lambada.songsync.activities.quicksearch.components.SyncedLyricsColumn
@@ -154,8 +155,7 @@ fun QuickLyricsSearchPage(
                                                                 lyricsList = parsedLyrics,
                                                                 modifier = Modifier
                                                                     .heightIn(
-                                                                        min = 200.dp,
-                                                                        max = 600.dp
+                                                                        min = 200.dp, max = 600.dp
                                                                     )
                                                                     .fillMaxWidth()
                                                                     .padding(8.dp)
@@ -165,7 +165,12 @@ fun QuickLyricsSearchPage(
                                                 }
 
                                                 is ResourceState.Error<*> -> {
-                                                    Text("Error: ${lyricsState.message}")
+                                                    ErrorCard(
+                                                        modifier = Modifier
+                                                            .fillMaxWidth()
+                                                            .heightIn(max = 300.dp),
+                                                        stacktrace = lyricsState.message ?: ""
+                                                    )
                                                 }
                                             }
                                         }
@@ -174,7 +179,13 @@ fun QuickLyricsSearchPage(
                             }
 
                             is ScreenState.Error -> {
-                                Text("Error: ${animatedPageState.exception.message}")
+                                ErrorCard(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .heightIn(max = 300.dp),
+                                    stacktrace = animatedPageState.exception.message
+                                        ?: animatedPageState.exception.stackTrace.toString()
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/QuickLyricsSearchPage.kt
@@ -1,6 +1,5 @@
 package pl.lambada.songsync.activities.quicksearch
 
-import android.util.Log
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,7 +13,6 @@ import androidx.compose.material.icons.automirrored.rounded.Send
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.rounded.Subtitles
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -22,10 +20,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -42,7 +36,6 @@ import pl.lambada.songsync.activities.quicksearch.components.SyncedLyricsColumn
 import pl.lambada.songsync.activities.quicksearch.viewmodel.QuickLyricsSearchViewModel
 import pl.lambada.songsync.util.ResourceState
 import pl.lambada.songsync.util.ScreenState
-import pl.lambada.songsync.util.parseLyrics
 
 @Composable
 fun QuickLyricsSearchPage(
@@ -175,7 +168,7 @@ fun QuickLyricsSearchPage(
                                         is ResourceState.Success<*> -> {
                                             state.value.lyricsState.data?.let { _ -> //This crunches the animation lol
                                                 ExpandableOutlinedCard(
-                                                   title = stringResource(R.string.song_lyrics),
+                                                    title = stringResource(R.string.song_lyrics),
                                                     subtitle = stringResource(R.string.lyrics_subtitle),
                                                     icon = Icons.Rounded.Subtitles,
                                                     isExpanded = false,
@@ -183,7 +176,9 @@ fun QuickLyricsSearchPage(
                                                 ) {
                                                     SyncedLyricsColumn(
                                                         lyricsList = state.value.parsedLyrics,
-                                                        modifier = Modifier.fillMaxWidth().padding(8.dp)
+                                                        modifier = Modifier
+                                                            .fillMaxWidth()
+                                                            .padding(8.dp)
                                                     )
                                                 }
                                             }

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/ErrorCard.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/ErrorCard.kt
@@ -1,0 +1,97 @@
+package pl.lambada.songsync.activities.quicksearch.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Error
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import pl.lambada.songsync.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ErrorCard(
+    stacktrace: String,
+    modifier: Modifier = Modifier
+) {
+    OutlinedCard(
+        modifier = modifier,
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+        ),
+        shape = MaterialTheme.shapes.small
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                modifier = Modifier.weight(0.1f),
+                imageVector = Icons.Rounded.Error,
+                contentDescription = stringResource(R.string.error),
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(6.dp)
+                    .weight(1f),
+            ) {
+                Text(
+                    modifier = Modifier.alpha(0.65f),
+                    text = stringResource(R.string.unknown_error_occurred).uppercase(),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = stacktrace,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Normal
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ErrorCardPreview() {
+    ErrorCard(
+        modifier = Modifier.heightIn(max = 300.dp),
+        stacktrace = "java.lang.IllegalArgumentException: Unsupported AnimationVector type\n" +
+                "                                                                                                    \tat pl.lambada.songsync.util.ui.DurationBasedCustomAnimationsKt.minus(DurationBasedCustomAnimations.kt:112)\n" +
+                "                                                                                                    \tat pl.lambada.songsync.util.ui.DurationBasedCustomAnimationsKt.access\$minus(DurationBasedCustomAnimations.kt:1)\n" +
+                "                                                                                                    \tat pl.lambada.songsync.util.ui.VectorizedPixelAnimationSpec.getValueFromNanos(DurationBasedCustomAnimations.kt:57)\n" +
+                "                                                                                                    \tat androidx.compose.animation.core.TargetBasedAnimation.getValueFromNanos(Animation.kt:265)\n" +
+                "                                                                                                    \tat androidx.compose.animation.core.Transition\$TransitionAnimationState.seekTo\$animation_core_release(Transition.kt:1416)\n" +
+                "                                                                                                    \tat androidx.compose.animation.core.Transition.seekAnimations\$animation_core_release(Transition.kt:1256)\n" +
+                "                                                                                                    \tat androidx.compose.animation.core.Transition.seekAnimations\$animation_core_release(Transition.kt:1260)\n" +
+                "                                                                                                    \tat androidx.compose.animation.core.Transition.seekAnimations\$animation_core_release(Transition.kt:1260)\n" +
+                "                                                                                                    \tat androidx.compose.animation.core.SeekableTransitionState.seekToFraction(Transition.kt:744)\n" +
+                "                                                                                                    \tat androidx.compose.animation.core.SeekableTransitionState.access\$seekToFraction(Transition.kt:224)\n" +
+                "                                                                                                    \tat androidx.compose.animation.core.SeekableTransitionState\$animateOneFrameLambda\$1.invoke(Transition.kt:333)\n" +
+                "                                                                                                    \tat androidx.compose.animation.core.SeekableTransitionState\$animateOneFrameLambda\$1.invoke(Transition.kt:311)\n" +
+                "                                                                                                    \tat androidx.compose.runtime.BroadcastFrameClock\$FrameAwaiter.resume(BroadcastFrameClock.kt:42)"
+    )
+}

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/ExpandableOutlinedCard.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/ExpandableOutlinedCard.kt
@@ -1,0 +1,109 @@
+package pl.lambada.songsync.activities.quicksearch.components
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.PermDeviceInformation
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ExpandableOutlinedCard(
+    modifier: Modifier = Modifier,
+    isExpanded: Boolean = false,
+    title: String,
+    subtitle: String,
+    icon: ImageVector,
+    content: @Composable () -> Unit,
+) {
+    var expanded by rememberSaveable { mutableStateOf(isExpanded) }
+
+    val animatedDegree =
+        animateFloatAsState(targetValue = if (expanded) 0f else -180f, label = "Button Rotation")
+
+    OutlinedCard(
+        modifier = modifier.animateContentSize(),
+        onClick = { expanded = !expanded },
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+        shape = MaterialTheme.shapes.small
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                modifier = Modifier.weight(0.1f),
+                imageVector = icon,
+                contentDescription = null,
+            )
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(6.dp).weight(1f),
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.62f),
+                    fontWeight = FontWeight.Normal
+                )
+            }
+            FilledTonalIconButton(
+                modifier = Modifier.size(24.dp),
+                onClick = { expanded = !expanded }
+            ) {
+                Icon(
+                    Icons.Outlined.ExpandLess,
+                    null,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.rotate(animatedDegree.value)
+                )
+            }
+        }
+        AnimatedVisibility(visible = expanded) {
+            content()
+        }
+    }
+}
+
+@Composable
+@Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+private fun ExpandableElevatedCardPreview() {
+    ExpandableOutlinedCard(
+        title = "Title", subtitle = "Subtitle", content = {
+            Text(text = "Content")
+        }, icon = Icons.Outlined.PermDeviceInformation
+    )
+}

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/ExpandableOutlinedCard.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/ExpandableOutlinedCard.kt
@@ -13,8 +13,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.PermDeviceInformation
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -56,7 +54,9 @@ fun ExpandableOutlinedCard(
         shape = MaterialTheme.shapes.small
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
@@ -65,7 +65,10 @@ fun ExpandableOutlinedCard(
                 contentDescription = null,
             )
             Column(
-                modifier = Modifier.fillMaxWidth().padding(6.dp).weight(1f),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(6.dp)
+                    .weight(1f),
             ) {
                 Text(
                     text = title,

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/ExpandableOutlinedCard.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/ExpandableOutlinedCard.kt
@@ -27,9 +27,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import pl.lambada.songsync.R
 
 @Composable
 fun ExpandableOutlinedCard(
@@ -62,7 +64,7 @@ fun ExpandableOutlinedCard(
             Icon(
                 modifier = Modifier.weight(0.1f),
                 imageVector = icon,
-                contentDescription = null,
+                contentDescription = stringResource(R.string.song_lyrics),
             )
             Column(
                 modifier = Modifier
@@ -87,8 +89,8 @@ fun ExpandableOutlinedCard(
                 onClick = { expanded = !expanded }
             ) {
                 Icon(
-                    Icons.Outlined.ExpandLess,
-                    null,
+                    imageVector = Icons.Outlined.ExpandLess,
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.onPrimaryContainer,
                     modifier = Modifier.rotate(animatedDegree.value)
                 )

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/ExpandableOutlinedCard.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/ExpandableOutlinedCard.kt
@@ -15,9 +15,11 @@ import androidx.compose.material.icons.outlined.PermDeviceInformation
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -86,7 +88,10 @@ fun ExpandableOutlinedCard(
             }
             FilledTonalIconButton(
                 modifier = Modifier.size(24.dp),
-                onClick = { expanded = !expanded }
+                onClick = { expanded = !expanded },
+                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(4.dp),
+                )
             ) {
                 Icon(
                     imageVector = Icons.Outlined.ExpandLess,

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/QuickLyricsSongInfo.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/QuickLyricsSongInfo.kt
@@ -53,7 +53,9 @@ fun QuickLyricsSongInfo(
         )
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/QuickLyricsSongInfo.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/QuickLyricsSongInfo.kt
@@ -1,0 +1,126 @@
+package pl.lambada.songsync.activities.quicksearch.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.ImageLoader
+import coil.compose.AsyncImage
+import pl.lambada.songsync.R
+import pl.lambada.songsync.activities.quicksearch.QuickLyricsSearchActivity
+import pl.lambada.songsync.domain.model.SongInfo
+
+@Composable
+fun QuickLyricsSongInfo(
+    modifier: Modifier = Modifier,
+    songInfo: SongInfo,
+    imageLoader: ImageLoader = QuickLyricsSearchActivity.activityImageLoader
+) {
+
+    val imageUrl: String? by remember(songInfo.albumCoverLink) {
+        mutableStateOf(songInfo.albumCoverLink)
+    }
+
+    OutlinedCard(
+        modifier = modifier,
+        colors = CardDefaults.outlinedCardColors().copy(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        border = CardDefaults.outlinedCardBorder().copy(
+            width = 2.dp,
+        )
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsyncImage(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(MaterialTheme.shapes.small),
+                model = imageUrl,
+                contentDescription = stringResource(R.string.album_cover),
+                imageLoader = imageLoader,
+            )
+            Column(
+                modifier = Modifier,
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text(
+                    text = songInfo.songName ?: stringResource(R.string.unknown),
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontWeight = FontWeight.SemiBold
+                    )
+                )
+
+                Text(
+                    text = songInfo.artistName ?: stringResource(R.string.unknown),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TextWithIcon(
+    icon: ImageVector,
+    text: String,
+    textStyle: TextStyle = MaterialTheme.typography.bodyLarge
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null
+        )
+        Text(text = text, style = textStyle)
+    }
+}
+
+@Preview
+@Composable
+private fun TextWithIconPreview() {
+    TextWithIcon(
+        icon = Icons.Rounded.MusicNote,
+        text = "Song Name"
+    )
+}
+
+@Preview
+@Composable
+private fun QuickLyricsSongInfoPreview() {
+    QuickLyricsSongInfo(
+        songInfo = SongInfo(
+            songName = "Song Name",
+            artistName = "Artist Name",
+            albumCoverLink = "https://example.com/image.jpg"
+        )
+    )
+}

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SquaredButton.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SquaredButton.kt
@@ -1,5 +1,6 @@
 package pl.lambada.songsync.activities.quicksearch.components
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,6 +19,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -63,10 +65,15 @@ fun ButtonWithIconAndText(
     shape: CornerBasedShape = MaterialTheme.shapes.small,
     onClick: () -> Unit = {}
 ) {
+
+    val animatedAlpha by animateFloatAsState(
+        targetValue = if (enabled) 1f else 0.4f
+    )
+
     Surface(
         modifier = modifier
             .semantics { role = Role.Button }
-            .alpha(if (enabled) 1f else 0.4f),
+            .alpha(animatedAlpha),
         onClick = onClick,
         enabled = enabled,
         shape = shape,

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SquaredButton.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SquaredButton.kt
@@ -1,6 +1,7 @@
 package pl.lambada.songsync.activities.quicksearch.components
 
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -61,6 +62,7 @@ fun ButtonWithIconAndText(
     icon: ImageVector,
     text: String,
     enabled: Boolean = true,
+    border: Boolean = false,
     backgroundColor: Color = MaterialTheme.colorScheme.secondaryContainer,
     shape: CornerBasedShape = MaterialTheme.shapes.small,
     onClick: () -> Unit = {}
@@ -77,6 +79,7 @@ fun ButtonWithIconAndText(
         onClick = onClick,
         enabled = enabled,
         shape = shape,
+        border = if (border) BorderStroke(1.dp, MaterialTheme.colorScheme.outline) else null,
         color = backgroundColor
     ) {
         Column(

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SquaredButton.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SquaredButton.kt
@@ -61,10 +61,12 @@ fun ButtonWithIconAndText(
     enabled: Boolean = true,
     backgroundColor: Color = MaterialTheme.colorScheme.secondaryContainer,
     shape: CornerBasedShape = MaterialTheme.shapes.small,
-    onClick : () -> Unit = {}
+    onClick: () -> Unit = {}
 ) {
     Surface(
-        modifier = modifier.semantics { role = Role.Button }.alpha(if (enabled) 1f else 0.4f),
+        modifier = modifier
+            .semantics { role = Role.Button }
+            .alpha(if (enabled) 1f else 0.4f),
         onClick = onClick,
         enabled = enabled,
         shape = shape,

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SquaredButton.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SquaredButton.kt
@@ -1,0 +1,105 @@
+package pl.lambada.songsync.activities.quicksearch.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SquareButtons() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        ButtonWithIconAndText(
+            icon = Icons.Default.Home,
+            text = "Home",
+            modifier = Modifier.size(96.dp),
+            shape = RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)
+        )
+        ButtonWithIconAndText(
+            icon = Icons.Default.Settings,
+            text = "Settings",
+            modifier = Modifier.size(96.dp),
+            shape = RoundedCornerShape(topEnd = 8.dp, bottomEnd = 8.dp)
+        )
+    }
+}
+
+@Composable
+fun ButtonWithIconAndText(
+    modifier: Modifier = Modifier,
+    icon: ImageVector,
+    text: String,
+    enabled: Boolean = true,
+    backgroundColor: Color = MaterialTheme.colorScheme.secondaryContainer,
+    shape: CornerBasedShape = MaterialTheme.shapes.small,
+    onClick : () -> Unit = {}
+) {
+    Surface(
+        modifier = modifier.semantics { role = Role.Button }.alpha(if (enabled) 1f else 0.4f),
+        onClick = onClick,
+        enabled = enabled,
+        shape = shape,
+        color = backgroundColor
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterVertically),
+            modifier = Modifier
+                .padding(8.dp)
+                .defaultMinSize(
+                    minWidth = ButtonDefaults.MinWidth,
+                    minHeight = ButtonDefaults.MinHeight
+                )
+                .fillMaxWidth()
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    fontWeight = FontWeight.Medium,
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun SquareButtonsPreview() {
+    SquareButtons()
+}

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SyncedLyricsLine.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SyncedLyricsLine.kt
@@ -11,9 +11,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -27,13 +27,20 @@ fun SyncedLyricsLine(
     Row(modifier = modifier) {
         val formattedTime = buildAnnotatedString {
             append(time.substring(0, time.length - 4))
-            withStyle(style = SpanStyle(fontSize = 12.sp, color = Color.Gray.copy(alpha = 0.7f))) {
+            withStyle(
+                style = SpanStyle(
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                )
+            ) {
                 append(time.takeLast(4))
             }
         }
         Text(
             text = formattedTime,
-            style = MaterialTheme.typography.bodyMedium
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontFamily = FontFamily.Monospace
+            )
         )
         Spacer(modifier = Modifier.width(8.dp))
         Text(

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SyncedLyricsLine.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/components/SyncedLyricsLine.kt
@@ -1,0 +1,59 @@
+package pl.lambada.songsync.activities.quicksearch.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun SyncedLyricsLine(
+    time: String,
+    lyrics: String,
+    modifier: Modifier = Modifier
+) {
+    Row(modifier = modifier) {
+        val formattedTime = buildAnnotatedString {
+            append(time.substring(0, time.length - 4))
+            withStyle(style = SpanStyle(fontSize = 12.sp, color = Color.Gray.copy(alpha = 0.7f))) {
+                append(time.takeLast(4))
+            }
+        }
+        Text(
+            text = formattedTime,
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = lyrics,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Composable
+fun SyncedLyricsColumn(
+    lyricsList: List<Pair<String, String>>,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.verticalScroll(rememberScrollState())
+    ) {
+        lyricsList.forEach { (time, lyrics) ->
+            SyncedLyricsLine(time = time, lyrics = lyrics)
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+    }
+}

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/viewmodel/QuickLyricsSearchViewModel.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/viewmodel/QuickLyricsSearchViewModel.kt
@@ -20,7 +20,7 @@ import pl.lambada.songsync.util.parseLyrics
 class QuickLyricsSearchViewModel(
     val userSettingsController: UserSettingsController,
     private val lyricsProviderService: LyricsProviderService
-): ViewModel() {
+) : ViewModel() {
     private val mutableState = MutableStateFlow(QuickSearchViewState())
     val state = mutableState.asStateFlow()
 
@@ -55,7 +55,7 @@ class QuickLyricsSearchViewModel(
                 version = context.getVersion()
             )
 
-            if(syncedLyrics != null) {
+            if (syncedLyrics != null) {
                 updateLyricsState(ResourceState.Success(syncedLyrics))
                 parseLyrics(syncedLyrics).let { parsedLyrics ->
                     Log.d("QuickLyricsSearchVM", "Parsed lyrics: $parsedLyrics")
@@ -80,7 +80,7 @@ class QuickLyricsSearchViewModel(
         )
 
     private fun updateScreenState(screenState: ScreenState<SongInfo>) {
-        if(screenState != mutableState.value.screenState) {
+        if (screenState != mutableState.value.screenState) {
             mutableState.update {
                 it.copy(screenState = screenState)
             }
@@ -88,7 +88,7 @@ class QuickLyricsSearchViewModel(
     }
 
     private fun updateLyricsState(lyricsState: ResourceState<String>) {
-        if(lyricsState != mutableState.value.lyricsState) {
+        if (lyricsState != mutableState.value.lyricsState) {
             mutableState.update {
                 it.copy(lyricsState = lyricsState)
             }
@@ -96,7 +96,7 @@ class QuickLyricsSearchViewModel(
     }
 
     fun onEvent(event: Event) {
-        when(event) {
+        when (event) {
             is Event.Fetch -> {
                 mutableState.update {
                     it.copy(song = event.song)
@@ -107,6 +107,6 @@ class QuickLyricsSearchViewModel(
     }
 
     interface Event {
-        data class Fetch(val song: Pair<String, String>, val context: Context): Event
+        data class Fetch(val song: Pair<String, String>, val context: Context) : Event
     }
 }

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/viewmodel/QuickLyricsSearchViewModel.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/viewmodel/QuickLyricsSearchViewModel.kt
@@ -1,0 +1,104 @@
+package pl.lambada.songsync.activities.quicksearch.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pl.lambada.songsync.data.UserSettingsController
+import pl.lambada.songsync.data.remote.lyrics_providers.LyricsProviderService
+import pl.lambada.songsync.domain.model.SongInfo
+import pl.lambada.songsync.util.ResourceState
+import pl.lambada.songsync.util.ScreenState
+import pl.lambada.songsync.util.ext.getVersion
+
+class QuickLyricsSearchViewModel(
+    val userSettingsController: UserSettingsController,
+    private val lyricsProviderService: LyricsProviderService
+): ViewModel() {
+
+    private val mutableState = MutableStateFlow(QuickSearchViewState())
+    val state = mutableState.asStateFlow()
+
+    data class QuickSearchViewState(
+        val song: Pair<String, String>? = null, // Pair of song title and artist's name
+        val screenState: ScreenState<SongInfo> = ScreenState.Loading,
+        val lyricsState: ResourceState<String> = ResourceState.Loading()
+    )
+
+    private fun fetchSongData(song: Pair<String, String>, context: Context) {
+        updateScreenState(ScreenState.Loading)
+        viewModelScope.launch(Dispatchers.IO) {
+            val result = lyricsProviderService
+                .getSongInfo(
+                    query = SongInfo(song.first, song.second),
+                    offset = 0,
+                    provider = userSettingsController.selectedProvider
+                )
+                ?: return@launch updateScreenState(ScreenState.Error(Exception("Error fetching lyrics for the song.")))
+
+            updateScreenState(ScreenState.Success(result))
+            fetchLyrics(result.songLink, context)
+        }
+    }
+
+    private fun fetchLyrics(songLink: String?, context: Context) {
+        updateLyricsState(ResourceState.Loading())
+        viewModelScope.launch(Dispatchers.IO) {
+            val syncedLyrics = getSyncedLyrics(
+                link = songLink,
+                version = context.getVersion()
+            )
+
+            if(syncedLyrics != null) {
+                updateLyricsState(ResourceState.Success(syncedLyrics))
+            } else {
+                updateLyricsState(ResourceState.Error("Error fetching lyrics for the song."))
+            }
+        }
+    }
+
+    private suspend fun getSyncedLyrics(link: String?, version: String): String? =
+        lyricsProviderService.getSyncedLyrics(
+            link,
+            version,
+            userSettingsController.selectedProvider,
+            userSettingsController.includeTranslation,
+            userSettingsController.multiPersonWordByWord,
+            userSettingsController.syncedMusixmatch
+        )
+
+    private fun updateScreenState(screenState: ScreenState<SongInfo>) {
+        if(screenState != mutableState.value.screenState) {
+            mutableState.update {
+                it.copy(screenState = screenState)
+            }
+        }
+    }
+
+    private fun updateLyricsState(lyricsState: ResourceState<String>) {
+        if(lyricsState != mutableState.value.lyricsState) {
+            mutableState.update {
+                it.copy(lyricsState = lyricsState)
+            }
+        }
+    }
+
+    fun onEvent(event: Event) {
+        when(event) {
+            is Event.Fetch -> {
+                mutableState.update {
+                    it.copy(song = event.song)
+                }
+                fetchSongData(event.song, event.context)
+            }
+        }
+    }
+
+    interface Event {
+        data class Fetch(val song: Pair<String, String>, val context: Context): Event
+    }
+}

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/viewmodel/QuickLyricsSearchViewModel.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/viewmodel/QuickLyricsSearchViewModel.kt
@@ -1,7 +1,6 @@
 package pl.lambada.songsync.activities.quicksearch.viewmodel
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
@@ -9,6 +8,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import pl.lambada.songsync.R
 import pl.lambada.songsync.data.UserSettingsController
 import pl.lambada.songsync.data.remote.lyrics_providers.LyricsProviderService
 import pl.lambada.songsync.domain.model.SongInfo
@@ -33,38 +33,76 @@ class QuickLyricsSearchViewModel(
 
     private fun fetchSongData(song: Pair<String, String>, context: Context) {
         updateScreenState(ScreenState.Loading)
-        viewModelScope.launch(Dispatchers.IO) {
-            val result = lyricsProviderService
-                .getSongInfo(
-                    query = SongInfo(song.first, song.second),
-                    offset = 0,
-                    provider = userSettingsController.selectedProvider
-                )
-                ?: return@launch updateScreenState(ScreenState.Error(Exception("Error fetching lyrics for the song.")))
 
-            updateScreenState(ScreenState.Success(result))
-            fetchLyrics(result.songLink, context)
+        viewModelScope.launch(Dispatchers.IO) {
+            val songInfoCall = runCatching {
+                lyricsProviderService
+                    .getSongInfo(
+                        query = SongInfo(song.first, song.second),
+                        offset = 0,
+                        provider = userSettingsController.selectedProvider
+                    )
+            }
+
+            if (songInfoCall.isSuccess) {
+                val result = songInfoCall.getOrNull()
+
+                if (result == null) {
+                    updateScreenState(
+                        ScreenState.Error(
+                            Exception("The song information retrieved is null")
+                        )
+                    )
+                } else {
+                    updateScreenState(ScreenState.Success(result))
+                    fetchLyrics(result.songLink, context)
+                }
+
+            } else {
+                val exception = songInfoCall.exceptionOrNull()
+                updateScreenState(
+                    ScreenState.Error(
+                        exception ?: Exception("An unknown error has occurred")
+                    )
+                )
+            }
         }
     }
 
     private fun fetchLyrics(songLink: String?, context: Context) {
         updateLyricsState(ResourceState.Loading())
         viewModelScope.launch(Dispatchers.IO) {
-            val syncedLyrics = getSyncedLyrics(
-                link = songLink,
-                version = context.getVersion()
-            )
 
-            if (syncedLyrics != null) {
-                updateLyricsState(ResourceState.Success(syncedLyrics))
-                parseLyrics(syncedLyrics).let { parsedLyrics ->
-                    Log.d("QuickLyricsSearchVM", "Parsed lyrics: $parsedLyrics")
-                    mutableState.update {
-                        it.copy(parsedLyrics = parsedLyrics)
+            val lyricsCall = runCatching {
+                getSyncedLyrics(
+                    link = songLink,
+                    version = context.getVersion()
+                )
+            }
+
+            if (lyricsCall.isSuccess) {
+
+                val syncedLyrics = lyricsCall.getOrNull()
+
+                if (syncedLyrics == null) updateLyricsState(
+                    ResourceState.Error("The fetched lyrics content is null.")
+                ) else {
+                    updateLyricsState(ResourceState.Success(syncedLyrics))
+                    parseLyrics(syncedLyrics).let { parsedLyrics ->
+                        mutableState.update {
+                            it.copy(parsedLyrics = parsedLyrics)
+                        }
                     }
                 }
+
             } else {
-                updateLyricsState(ResourceState.Error("Error fetching lyrics for the song."))
+                val exception = lyricsCall.exceptionOrNull()
+                updateLyricsState(
+                    ResourceState.Error(
+                        exception?.localizedMessage
+                            ?: (context.getString(R.string.unknown) + exception?.stackTrace.toString())
+                    )
+                )
             }
         }
     }

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/viewmodel/QuickLyricsSearchViewModel.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/viewmodel/QuickLyricsSearchViewModel.kt
@@ -81,7 +81,6 @@ class QuickLyricsSearchViewModel(
             }
 
             if (lyricsCall.isSuccess) {
-
                 val syncedLyrics = lyricsCall.getOrNull()
 
                 if (syncedLyrics == null) updateLyricsState(

--- a/app/src/main/java/pl/lambada/songsync/activities/quicksearch/viewmodel/QuickLyricsSearchViewModelFactory.kt
+++ b/app/src/main/java/pl/lambada/songsync/activities/quicksearch/viewmodel/QuickLyricsSearchViewModelFactory.kt
@@ -1,0 +1,19 @@
+package pl.lambada.songsync.activities.quicksearch.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import pl.lambada.songsync.data.UserSettingsController
+import pl.lambada.songsync.data.remote.lyrics_providers.LyricsProviderService
+
+class QuickLyricsSearchViewModelFactory(
+    private val userSettingsController: UserSettingsController,
+    private val lyricsProviderService: LyricsProviderService
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(QuickLyricsSearchViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return QuickLyricsSearchViewModel(userSettingsController, lyricsProviderService) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
@@ -49,8 +49,11 @@ class LyricsProviderService {
      * @return The SongInfo object containing the song information.
      */
     @Throws(
-        UnknownHostException::class, FileNotFoundException::class, NoTrackFoundException::class,
-        EmptyQueryException::class, InternalErrorException::class
+        UnknownHostException::class,
+        FileNotFoundException::class,
+        NoTrackFoundException::class,
+        EmptyQueryException::class,
+        InternalErrorException::class
     )
     suspend fun getSongInfo(query: SongInfo, offset: Int = 0, provider: Providers): SongInfo? {
         return try {
@@ -97,25 +100,20 @@ class LyricsProviderService {
         multiPersonWordByWord: Boolean = false,
         syncedMusixmatch: Boolean = true
     ): String? {
-        return try {
-            when (provider) {
-                Providers.SPOTIFY -> SpotifyLyricsAPI().getSyncedLyrics(songLink!!, version)
-                Providers.LRCLIB -> LRCLibAPI().getSyncedLyrics(lrcLibID)
-                Providers.NETEASE -> NeteaseAPI().getSyncedLyrics(
-                    neteaseID,
-                    includeTranslationNetEase
-                )
-                Providers.APPLE -> AppleAPI().getSyncedLyrics(
-                    appleID,
-                    multiPersonWordByWord
-                )
-                Providers.MUSIXMATCH -> MusixmatchAPI().getLyrics(
-                    musixmatchSongInfo,
-                    syncedMusixmatch
-                )
-            }
-        } catch (e: Exception) {
-            null
+        return when (provider) {
+            Providers.SPOTIFY -> SpotifyLyricsAPI().getSyncedLyrics(songLink!!, version)
+            Providers.LRCLIB -> LRCLibAPI().getSyncedLyrics(lrcLibID)
+            Providers.NETEASE -> NeteaseAPI().getSyncedLyrics(
+                neteaseID, includeTranslationNetEase
+            )
+
+            Providers.APPLE -> AppleAPI().getSyncedLyrics(
+                appleID, multiPersonWordByWord
+            )
+
+            Providers.MUSIXMATCH -> MusixmatchAPI().getLyrics(
+                musixmatchSongInfo, syncedMusixmatch
+            )
         }
     }
 }

--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
@@ -75,14 +75,11 @@ class LyricsProviderService {
                     musixmatchSongInfo = it
                 } ?: throw NoTrackFoundException()
             }
-        } catch (e: InternalErrorException) {
-            throw e
-        } catch (e: NoTrackFoundException) {
-            throw e
-        } catch (e: EmptyQueryException) {
-            throw e
         } catch (e: Exception) {
-            throw InternalErrorException(Log.getStackTraceString(e))
+            when (e) {
+                is InternalErrorException, is NoTrackFoundException, is EmptyQueryException -> throw e
+                else -> throw InternalErrorException(Log.getStackTraceString(e))
+            }
         }
     }
 

--- a/app/src/main/java/pl/lambada/songsync/ui/Navigator.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/Navigator.kt
@@ -6,17 +6,17 @@ import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import kotlinx.serialization.Serializable
 import pl.lambada.songsync.data.UserSettingsController
 import pl.lambada.songsync.data.remote.lyrics_providers.LyricsProviderService
-import pl.lambada.songsync.ui.screens.settings.SettingsScreen
-import pl.lambada.songsync.ui.screens.settings.SettingsViewModel
+import pl.lambada.songsync.ui.common.animatedComposable
 import pl.lambada.songsync.ui.screens.home.HomeScreen
 import pl.lambada.songsync.ui.screens.home.HomeViewModel
 import pl.lambada.songsync.ui.screens.lyricsFetch.LyricsFetchScreen
 import pl.lambada.songsync.ui.screens.lyricsFetch.LyricsFetchViewModel
+import pl.lambada.songsync.ui.screens.settings.SettingsScreen
+import pl.lambada.songsync.ui.screens.settings.SettingsViewModel
 
 /**
  * Composable function for handling navigation within the app.
@@ -35,7 +35,7 @@ fun Navigator(
             navController = navController,
             startDestination = ScreenHome
         ) {
-            composable<ScreenHome> {
+            animatedComposable<ScreenHome> {
                 HomeScreen(
                     navController = navController,
                     viewModel = viewModel {
@@ -46,7 +46,7 @@ fun Navigator(
                 )
             }
 
-            composable<LyricsFetchScreen>() {
+            animatedComposable<LyricsFetchScreen>() {
                 val args = it.toRoute<LyricsFetchScreen>()
 
                 LyricsFetchScreen(
@@ -61,7 +61,7 @@ fun Navigator(
                     animatedVisibilityScope = this,
                 )
             }
-            composable<ScreenSettings> {
+            animatedComposable<ScreenSettings> {
                 SettingsScreen(
                     viewModel = viewModel { SettingsViewModel() },
                     userSettingsController,

--- a/app/src/main/java/pl/lambada/songsync/ui/common/AnimatedComposables.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/common/AnimatedComposables.kt
@@ -1,0 +1,126 @@
+package pl.lambada.songsync.ui.common
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.IntOffset
+import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDeepLink
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import pl.lambada.songsync.util.ui.MotionConstants.DURATION_EXIT
+import pl.lambada.songsync.util.ui.MotionConstants.InitialOffset
+import pl.lambada.songsync.util.ui.materialSharedAxisXIn
+import pl.lambada.songsync.util.ui.materialSharedAxisXOut
+import pl.lambada.songsync.util.ui.materialSharedAxisYIn
+import pl.lambada.songsync.util.ui.materialSharedAxisYOut
+import pl.lambada.songsync.util.ui.tweenEnter
+import pl.lambada.songsync.util.ui.tweenExit
+import kotlin.reflect.KType
+
+fun NavGraphBuilder.fadeThroughComposable(
+    route: String,
+    arguments: List<NamedNavArgument> = emptyList(),
+    deepLinks: List<NavDeepLink> = emptyList(),
+    content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
+) = composable(
+    route = route,
+    arguments = arguments,
+    deepLinks = deepLinks,
+    enterTransition = {
+        fadeIn(animationSpec = tween(220, delayMillis = 90)) +
+                scaleIn(
+                    initialScale = 0.92f,
+                    animationSpec = tween(220, delayMillis = 90)
+                )
+    },
+    exitTransition = {
+        fadeOut(animationSpec = tween(90))
+    },
+    popEnterTransition = {
+        fadeIn(animationSpec = tween(220, delayMillis = 90)) +
+                scaleIn(
+                    initialScale = 0.92f,
+                    animationSpec = tween(220, delayMillis = 90)
+                )
+    },
+    popExitTransition = {
+        fadeOut(animationSpec = tween(90))
+    },
+    content = content
+)
+
+val enterTween = tweenEnter<IntOffset>()
+val exitTween = tweenExit<IntOffset>()
+val fadeTween = tween<Float>(durationMillis = DURATION_EXIT)
+
+
+inline fun <reified T : Any> NavGraphBuilder.animatedComposable(
+    deepLinks: List<NavDeepLink> = emptyList(),
+    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
+) = composable<T>(
+    deepLinks = deepLinks,
+    enterTransition = {
+        materialSharedAxisXIn(initialOffsetX = { (it * InitialOffset).toInt() })
+    },
+    exitTransition = {
+        materialSharedAxisXOut(targetOffsetX = { -(it * InitialOffset).toInt() })
+    },
+    popEnterTransition = {
+        materialSharedAxisXIn(initialOffsetX = { -(it * InitialOffset).toInt() })
+    },
+    popExitTransition = {
+        materialSharedAxisXOut(targetOffsetX = { (it * InitialOffset).toInt() })
+    },
+    content = content
+)
+
+inline fun <reified T : Any> NavGraphBuilder.animatedComposableVariant(
+    deepLinks: List<NavDeepLink> = emptyList(),
+    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
+) = composable<T>(
+    deepLinks = deepLinks,
+    enterTransition = {
+        materialSharedAxisYIn(initialOffsetY = { (it * InitialOffset).toInt() })
+    },
+    exitTransition = {
+        materialSharedAxisYOut(targetOffsetY = { -(it * InitialOffset).toInt() })
+    },
+    popEnterTransition = {
+        materialSharedAxisYIn(initialOffsetY = { -(it * InitialOffset).toInt() })
+    },
+    popExitTransition = {
+        materialSharedAxisYOut(targetOffsetY = { (it * InitialOffset).toInt() })
+    },
+    content = content
+)
+
+inline fun <reified T : Any> NavGraphBuilder.slideInVerticallyComposable(
+    deepLinks: List<NavDeepLink> = emptyList(),
+    typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
+    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
+) = composable<T>(
+    deepLinks = deepLinks,
+    enterTransition = {
+        slideInVertically(
+            initialOffsetY = { it }, animationSpec = enterTween
+        ) + fadeIn()
+    },
+    typeMap = typeMap,
+    exitTransition = { slideOutVertically() },
+    popEnterTransition = { slideInVertically() },
+    popExitTransition = {
+        slideOutVertically(
+            targetOffsetY = { it },
+            animationSpec = enterTween
+        ) + fadeOut()
+    },
+    content = content
+)

--- a/app/src/main/java/pl/lambada/songsync/ui/common/AnimatedComposables.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/common/AnimatedComposables.kt
@@ -1,126 +1,185 @@
 package pl.lambada.songsync.ui.common
 
+import android.os.Build
 import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.VisibilityThreshold
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.IntOffset
-import androidx.navigation.NamedNavArgument
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDeepLink
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import pl.lambada.songsync.util.ui.EmphasizedAccelerate
+import pl.lambada.songsync.util.ui.EmphasizedDecelerate
+import pl.lambada.songsync.util.ui.EmphasizedEasing
+import pl.lambada.songsync.util.ui.MotionConstants.DURATION_ENTER
 import pl.lambada.songsync.util.ui.MotionConstants.DURATION_EXIT
 import pl.lambada.songsync.util.ui.MotionConstants.InitialOffset
 import pl.lambada.songsync.util.ui.materialSharedAxisXIn
 import pl.lambada.songsync.util.ui.materialSharedAxisXOut
 import pl.lambada.songsync.util.ui.materialSharedAxisYIn
 import pl.lambada.songsync.util.ui.materialSharedAxisYOut
-import pl.lambada.songsync.util.ui.tweenEnter
-import pl.lambada.songsync.util.ui.tweenExit
 import kotlin.reflect.KType
 
-fun NavGraphBuilder.fadeThroughComposable(
-    route: String,
-    arguments: List<NamedNavArgument> = emptyList(),
-    deepLinks: List<NavDeepLink> = emptyList(),
-    content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
-) = composable(
-    route = route,
-    arguments = arguments,
-    deepLinks = deepLinks,
-    enterTransition = {
-        fadeIn(animationSpec = tween(220, delayMillis = 90)) +
-                scaleIn(
-                    initialScale = 0.92f,
-                    animationSpec = tween(220, delayMillis = 90)
-                )
-    },
-    exitTransition = {
-        fadeOut(animationSpec = tween(90))
-    },
-    popEnterTransition = {
-        fadeIn(animationSpec = tween(220, delayMillis = 90)) +
-                scaleIn(
-                    initialScale = 0.92f,
-                    animationSpec = tween(220, delayMillis = 90)
-                )
-    },
-    popExitTransition = {
-        fadeOut(animationSpec = tween(90))
-    },
-    content = content
-)
+fun <T> enterTween() = tween<T>(durationMillis = DURATION_ENTER, easing = EmphasizedEasing)
 
-val enterTween = tweenEnter<IntOffset>()
-val exitTween = tweenExit<IntOffset>()
-val fadeTween = tween<Float>(durationMillis = DURATION_EXIT)
+fun <T> exitTween() = tween<T>(durationMillis = DURATION_ENTER, easing = EmphasizedEasing)
 
+private val fadeSpring =
+    spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMedium)
+
+private val fadeTween = tween<Float>(durationMillis = DURATION_EXIT)
+val fadeSpec = fadeTween
 
 inline fun <reified T : Any> NavGraphBuilder.animatedComposable(
     deepLinks: List<NavDeepLink> = emptyList(),
-    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
-) = composable<T>(
-    deepLinks = deepLinks,
-    enterTransition = {
-        materialSharedAxisXIn(initialOffsetX = { (it * InitialOffset).toInt() })
-    },
-    exitTransition = {
-        materialSharedAxisXOut(targetOffsetX = { -(it * InitialOffset).toInt() })
-    },
-    popEnterTransition = {
-        materialSharedAxisXIn(initialOffsetX = { -(it * InitialOffset).toInt() })
-    },
-    popExitTransition = {
-        materialSharedAxisXOut(targetOffsetX = { (it * InitialOffset).toInt() })
-    },
-    content = content
-)
-
-inline fun <reified T : Any> NavGraphBuilder.animatedComposableVariant(
-    deepLinks: List<NavDeepLink> = emptyList(),
-    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
-) = composable<T>(
-    deepLinks = deepLinks,
-    enterTransition = {
-        materialSharedAxisYIn(initialOffsetY = { (it * InitialOffset).toInt() })
-    },
-    exitTransition = {
-        materialSharedAxisYOut(targetOffsetY = { -(it * InitialOffset).toInt() })
-    },
-    popEnterTransition = {
-        materialSharedAxisYIn(initialOffsetY = { -(it * InitialOffset).toInt() })
-    },
-    popExitTransition = {
-        materialSharedAxisYOut(targetOffsetY = { (it * InitialOffset).toInt() })
-    },
-    content = content
-)
+    usePredictiveBack: Boolean = Build.VERSION.SDK_INT >= 34,
+    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit,
+) {
+    if (usePredictiveBack) {
+        animatedComposablePredictiveBack<T>(deepLinks, content)
+    } else {
+        animatedComposableLegacy<T>(deepLinks, content)
+    }
+}
 
 inline fun <reified T : Any> NavGraphBuilder.slideInVerticallyComposable(
     deepLinks: List<NavDeepLink> = emptyList(),
     typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
-    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
-) = composable<T>(
-    deepLinks = deepLinks,
-    enterTransition = {
-        slideInVertically(
-            initialOffsetY = { it }, animationSpec = enterTween
-        ) + fadeIn()
-    },
-    typeMap = typeMap,
-    exitTransition = { slideOutVertically() },
-    popEnterTransition = { slideInVertically() },
-    popExitTransition = {
-        slideOutVertically(
-            targetOffsetY = { it },
-            animationSpec = enterTween
-        ) + fadeOut()
-    },
-    content = content
-)
+    usePredictiveBack: Boolean = Build.VERSION.SDK_INT >= 34,
+    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit,
+) {
+    if (usePredictiveBack) {
+        slideInVerticallyComposablePredictiveBack<T>(deepLinks, typeMap, content)
+    } else {
+        slideInVerticallyComposableLegacy<T>(deepLinks, typeMap, content)
+    }
+}
+
+inline fun <reified T : Any> NavGraphBuilder.animatedComposablePredictiveBack(
+    deepLinks: List<NavDeepLink> = emptyList(),
+    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit,
+) =
+    composable<T>(
+        deepLinks = deepLinks,
+        enterTransition = { materialSharedAxisXIn(initialOffsetX = { (it * 0.15f).toInt() }) },
+        exitTransition = {
+            materialSharedAxisXOut(targetOffsetX = { -(it * InitialOffset).toInt() })
+        },
+        popEnterTransition = {
+            scaleIn(
+                animationSpec = tween(durationMillis = 350, easing = EmphasizedDecelerate),
+                initialScale = 0.9f,
+            ) + materialSharedAxisXIn(initialOffsetX = { -(it * InitialOffset).toInt() })
+        },
+        popExitTransition = {
+            materialSharedAxisXOut(targetOffsetX = { (it * InitialOffset).toInt() }) +
+                    scaleOut(
+                        targetScale = 0.9f,
+                        animationSpec = tween(durationMillis = 350, easing = EmphasizedAccelerate),
+                    )
+        },
+        content = content,
+    )
+
+inline fun <reified T : Any> NavGraphBuilder.animatedComposableLegacy(
+    deepLinks: List<NavDeepLink> = emptyList(),
+    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit,
+) =
+    composable<T>(
+        deepLinks = deepLinks,
+        enterTransition = {
+            materialSharedAxisXIn(initialOffsetX = { (it * InitialOffset).toInt() })
+        },
+        exitTransition = {
+            materialSharedAxisXOut(targetOffsetX = { -(it * InitialOffset).toInt() })
+        },
+        popEnterTransition = {
+            materialSharedAxisXIn(initialOffsetX = { -(it * InitialOffset).toInt() })
+        },
+        popExitTransition = {
+            materialSharedAxisXOut(targetOffsetX = { (it * InitialOffset).toInt() })
+        },
+        content = content,
+    )
+
+inline fun <reified T : Any> NavGraphBuilder.animatedComposableVariant(
+    deepLinks: List<NavDeepLink> = emptyList(),
+    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit,
+) =
+    composable<T>(
+        deepLinks = deepLinks,
+        enterTransition = {
+            slideInHorizontally(enterTween(), initialOffsetX = { (it * InitialOffset).toInt() }) +
+                    fadeIn(fadeSpec)
+        },
+        exitTransition = { fadeOut(fadeSpec) },
+        popEnterTransition = { fadeIn(fadeSpec) },
+        popExitTransition = {
+            slideOutHorizontally(exitTween(), targetOffsetX = { (it * InitialOffset).toInt() }) +
+                    fadeOut(fadeSpec)
+        },
+        content = content,
+    )
+
+val springSpec =
+    spring(stiffness = Spring.StiffnessMedium, visibilityThreshold = IntOffset.VisibilityThreshold)
+
+inline fun <reified T : Any> NavGraphBuilder.slideInVerticallyComposableLegacy(
+    deepLinks: List<NavDeepLink> = emptyList(),
+    typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
+    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit,
+) =
+    composable<T>(
+        deepLinks = deepLinks,
+        typeMap = typeMap,
+        enterTransition = {
+            slideInVertically(initialOffsetY = { it }, animationSpec = enterTween()) + fadeIn()
+        },
+        exitTransition = { slideOutVertically() },
+        popEnterTransition = { slideInVertically() },
+        popExitTransition = {
+            slideOutVertically(targetOffsetY = { it }, animationSpec = enterTween()) + fadeOut()
+        },
+        content = content,
+    )
+
+inline fun <reified T : Any> NavGraphBuilder.slideInVerticallyComposablePredictiveBack(
+    deepLinks: List<NavDeepLink> = emptyList(),
+    typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
+    noinline content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit,
+) =
+    composable<T>(
+        deepLinks = deepLinks,
+        typeMap = typeMap,
+        enterTransition = { materialSharedAxisYIn(initialOffsetY = { (it * 0.25f).toInt() }) },
+        exitTransition = {
+            materialSharedAxisYOut(targetOffsetY = { -(it * InitialOffset * 1.5f).toInt() })
+        },
+        popEnterTransition = {
+            scaleIn(
+                animationSpec = tween(durationMillis = 400, easing = EmphasizedDecelerate),
+                initialScale = 0.85f,
+            ) + materialSharedAxisYIn(initialOffsetY = { -(it * InitialOffset * 1.5f).toInt() })
+        },
+        popExitTransition = {
+            materialSharedAxisYOut(targetOffsetY = { (it * InitialOffset * 1.5f).toInt() }) +
+                    scaleOut(
+                        targetScale = 0.85f,
+                        animationSpec = tween(durationMillis = 400, easing = EmphasizedAccelerate),
+                    )
+        },
+        content = content,
+    )

--- a/app/src/main/java/pl/lambada/songsync/ui/common/ComposableAnimations.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/common/ComposableAnimations.kt
@@ -1,0 +1,20 @@
+package pl.lambada.songsync.ui.common
+
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.SizeTransform
+import pl.lambada.songsync.util.ui.materialSharedAxisXIn
+import pl.lambada.songsync.util.ui.materialSharedAxisXOut
+import pl.lambada.songsync.util.ui.materialSharedAxisYIn
+import pl.lambada.songsync.util.ui.materialSharedAxisYOut
+
+val AnimatedTextContentTransformation = ContentTransform(
+    materialSharedAxisXIn(initialOffsetX = { it / 10 }),
+    materialSharedAxisXOut(targetOffsetX = { -it / 10 }),
+    sizeTransform = SizeTransform(clip = false)
+)
+
+val AnimatedCardContentTransformation = ContentTransform(
+    materialSharedAxisYIn(initialOffsetY = { it / 10 }),
+    materialSharedAxisYOut(targetOffsetY = { -it / 10 }),
+    sizeTransform = SizeTransform(clip = false)
+)

--- a/app/src/main/java/pl/lambada/songsync/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/screens/home/HomeScreen.kt
@@ -194,35 +194,35 @@ fun HomeScreenLoaded(
             horizontalAlignment = Alignment.CenterHorizontally,
             contentPadding = scaffoldPadding
         ) {
-//            item {
-//                val launcher = rememberLauncherForActivityResult(
-//                    contract = ActivityResultContracts.StartActivityForResult()
-//                ) { result ->
-//                    if (result.resultCode == Activity.RESULT_OK) {
-//                        val receivedLyrics = result.data?.getStringExtra("lyrics")
-//                        if (receivedLyrics != null) {
-//                            lyrics = receivedLyrics
-//                        }
-//                    }
-//                }
-//                Button(
-//                    onClick = {
-//                        val intent = Intent("android.intent.action.SEND").apply {
-//                            putExtra("songName", "Faded")
-//                            putExtra("artistName", "Alan Walker")
-//                            type = "text/plain"
-//                            setPackage("pl.lambada.songsync")
-//                        }
-//                        launcher.launch(intent)
-//                    }
-//                ) {
-//                    Text("Launch intent")
-//                }
-//            }
-//
-//            item {
-//                Text(lyrics)
-//            }
+            item {
+                val launcher = rememberLauncherForActivityResult(
+                    contract = ActivityResultContracts.StartActivityForResult()
+                ) { result ->
+                    if (result.resultCode == Activity.RESULT_OK) {
+                        val receivedLyrics = result.data?.getStringExtra("lyrics")
+                        if (receivedLyrics != null) {
+                            lyrics = receivedLyrics
+                        }
+                    }
+                }
+                Button(
+                    onClick = {
+                        val intent = Intent("android.intent.action.SEND").apply {
+                            putExtra("songName", "Around the World")
+                            putExtra("artistName", "Niklas Dee")
+                            type = "text/plain"
+                            setPackage("pl.lambada.songsync")
+                        }
+                        launcher.launch(intent)
+                    }
+                ) {
+                    Text("Launch intent")
+                }
+            }
+
+            item {
+                Text(lyrics)
+            }
 
             item {
                 Column(

--- a/app/src/main/java/pl/lambada/songsync/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/screens/home/HomeScreen.kt
@@ -1,9 +1,5 @@
 package pl.lambada.songsync.ui.screens.home
 
-import android.app.Activity
-import android.content.Intent
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.ExperimentalSharedTransitionApi
@@ -19,13 +15,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,7 +34,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat.startActivity
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import pl.lambada.songsync.ui.LyricsFetchScreen
@@ -55,6 +48,7 @@ import pl.lambada.songsync.ui.screens.home.components.SongItem
 import pl.lambada.songsync.ui.screens.home.components.SortDialog
 import pl.lambada.songsync.util.ext.BackPressHandler
 import pl.lambada.songsync.util.ext.lowercaseWithLocale
+import pl.lambada.songsync.util.ui.SearchFABBoundsTransform
 
 /**
  * Composable function representing the home screen.
@@ -116,9 +110,11 @@ fun HomeScreen(
             with(sharedTransitionScope) {
                 FloatingActionButton(
                     modifier = Modifier
+                        .skipToLookaheadSize()
                         .sharedBounds(
                             sharedContentState = rememberSharedContentState(key = "fab"),
                             animatedVisibilityScope = animatedVisibilityScope,
+                            boundsTransform = SearchFABBoundsTransform,
                             resizeMode = SharedTransitionScope.ResizeMode.RemeasureToBounds,
                         ),
                     onClick = { navController.navigate(LyricsFetchScreen()) }
@@ -177,9 +173,6 @@ fun HomeScreenLoaded(
     animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
     val context = LocalContext.current
-    var lyrics by remember {
-        mutableStateOf("Awaiting lyrics...")
-    }
 
     Column {
         if (isBatchDownload) {
@@ -194,36 +187,6 @@ fun HomeScreenLoaded(
             horizontalAlignment = Alignment.CenterHorizontally,
             contentPadding = scaffoldPadding
         ) {
-            item {
-                val launcher = rememberLauncherForActivityResult(
-                    contract = ActivityResultContracts.StartActivityForResult()
-                ) { result ->
-                    if (result.resultCode == Activity.RESULT_OK) {
-                        val receivedLyrics = result.data?.getStringExtra("lyrics")
-                        if (receivedLyrics != null) {
-                            lyrics = receivedLyrics
-                        }
-                    }
-                }
-                Button(
-                    onClick = {
-                        val intent = Intent("android.intent.action.SEND").apply {
-                            putExtra("songName", "Around the World")
-                            putExtra("artistName", "Niklas Dee")
-                            type = "text/plain"
-                            setPackage("pl.lambada.songsync")
-                        }
-                        launcher.launch(intent)
-                    }
-                ) {
-                    Text("Launch intent")
-                }
-            }
-
-            item {
-                Text(lyrics)
-            }
-
             item {
                 Column(
                     modifier = Modifier.padding(

--- a/app/src/main/java/pl/lambada/songsync/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/screens/home/HomeScreen.kt
@@ -1,5 +1,9 @@
 package pl.lambada.songsync.ui.screens.home
 
+import android.app.Activity
+import android.content.Intent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.ExperimentalSharedTransitionApi
@@ -15,11 +19,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -34,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat.startActivity
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import pl.lambada.songsync.ui.LyricsFetchScreen
@@ -170,6 +177,9 @@ fun HomeScreenLoaded(
     animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
     val context = LocalContext.current
+    var lyrics by remember {
+        mutableStateOf("Awaiting lyrics...")
+    }
 
     Column {
         if (isBatchDownload) {
@@ -184,6 +194,36 @@ fun HomeScreenLoaded(
             horizontalAlignment = Alignment.CenterHorizontally,
             contentPadding = scaffoldPadding
         ) {
+//            item {
+//                val launcher = rememberLauncherForActivityResult(
+//                    contract = ActivityResultContracts.StartActivityForResult()
+//                ) { result ->
+//                    if (result.resultCode == Activity.RESULT_OK) {
+//                        val receivedLyrics = result.data?.getStringExtra("lyrics")
+//                        if (receivedLyrics != null) {
+//                            lyrics = receivedLyrics
+//                        }
+//                    }
+//                }
+//                Button(
+//                    onClick = {
+//                        val intent = Intent("android.intent.action.SEND").apply {
+//                            putExtra("songName", "Faded")
+//                            putExtra("artistName", "Alan Walker")
+//                            type = "text/plain"
+//                            setPackage("pl.lambada.songsync")
+//                        }
+//                        launcher.launch(intent)
+//                    }
+//                ) {
+//                    Text("Launch intent")
+//                }
+//            }
+//
+//            item {
+//                Text(lyrics)
+//            }
+
             item {
                 Column(
                     modifier = Modifier.padding(

--- a/app/src/main/java/pl/lambada/songsync/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/screens/home/HomeViewModel.kt
@@ -276,14 +276,18 @@ class HomeViewModel(
         lyricsProviderService.getSongInfo(query, provider = userSettingsController.selectedProvider)
 
     suspend fun getSyncedLyrics(link: String?, version: String): String? {
-        return lyricsProviderService.getSyncedLyrics(
-            link,
-            version,
-            provider = userSettingsController.selectedProvider,
-            includeTranslationNetEase = userSettingsController.includeTranslation,
-            multiPersonWordByWord = userSettingsController.multiPersonWordByWord,
-            syncedMusixmatch = userSettingsController.syncedMusixmatch
-        )
+        return try {
+            lyricsProviderService.getSyncedLyrics(
+                link,
+                version,
+                provider = userSettingsController.selectedProvider,
+                includeTranslationNetEase = userSettingsController.includeTranslation,
+                multiPersonWordByWord = userSettingsController.multiPersonWordByWord,
+                syncedMusixmatch = userSettingsController.syncedMusixmatch
+            )
+        } catch (e: Exception) {
+            null
+        }
     }
 
     fun selectSong(song: Song, newValue: Boolean) {

--- a/app/src/main/java/pl/lambada/songsync/util/LyricsUtils.kt
+++ b/app/src/main/java/pl/lambada/songsync/util/LyricsUtils.kt
@@ -347,3 +347,21 @@ fun applyOffsetToLyrics(lyrics: String, offset: Int): String {
         "${startChar}${applyOffset(minute, second, millisecond)}$endChar"
     }
 }
+
+fun parseLyrics(lyrics: String): List<Pair<String, String>> {
+    val timestampRegex = Regex("""[\[<](\d+):(\d+)\.(\d+)[]>]""")
+    val lines = lyrics.lines()
+
+    return lines.mapNotNull { line ->
+        val match = timestampRegex.find(line) ?: return@mapNotNull null
+        val (minute, second, millisecond) = match.destructured
+
+        val startChar = line[0]
+        val endChar = if (startChar == '[') ']' else '>'
+
+        val timestamp = "${minute}:${second}.${millisecond.padStart(3, '0')}"
+        val text = line.substringAfter(endChar).trim()
+
+        timestamp to text
+    }
+}

--- a/app/src/main/java/pl/lambada/songsync/util/ResourceState.kt
+++ b/app/src/main/java/pl/lambada/songsync/util/ResourceState.kt
@@ -1,0 +1,35 @@
+package pl.lambada.songsync.util
+
+/**
+ * A sealed class representing the state of a resource.
+ *
+ * @param T The type of data associated with the resource state.
+ * @property data The data associated with the resource state.
+ * @property message An optional message associated with the resource state.
+ */
+sealed class ResourceState<T>(val data: T? = null, val message: String? = null) {
+    /**
+     * Represents a loading state.
+     *
+     * @param T The type of data.
+     * @property data The data associated with the loading state.
+     */
+    class Loading<T>(data: T? = null) : ResourceState<T>(data)
+
+    /**
+     * Represents a success state with optional data.
+     *
+     * @param T The type of data.
+     * @property data The data associated with the success state.
+     */
+    class Success<T>(data: T?) : ResourceState<T>(data)
+
+    /**
+     * Represents an error state with an optional message and data.
+     *
+     * @param T The type of data.
+     * @property message The message associated with the error state.
+     * @property data The data associated with the error state.
+     */
+    class Error<T>(message: String, data: T? = null) : ResourceState<T>(data, message)
+}

--- a/app/src/main/java/pl/lambada/songsync/util/ScreenState.kt
+++ b/app/src/main/java/pl/lambada/songsync/util/ScreenState.kt
@@ -1,0 +1,28 @@
+package pl.lambada.songsync.util
+
+/**
+ * A sealed class representing the state of a screen.
+ *
+ * @param T The type of data associated with the success state.
+ */
+sealed class ScreenState<out T> {
+    /**
+     * Represents a loading state.
+     */
+    data object Loading : ScreenState<Nothing>()
+
+    /**
+     * Represents a success state with optional data.
+     *
+     * @param T The type of data.
+     * @property data The data associated with the success state.
+     */
+    data class Success<T>(val data: T?) : ScreenState<T>()
+
+    /**
+     * Represents an error state with an exception.
+     *
+     * @property exception The exception associated with the error state.
+     */
+    data class Error(val exception: Throwable) : ScreenState<Nothing>()
+}

--- a/app/src/main/java/pl/lambada/songsync/util/ext/ContextExt.kt
+++ b/app/src/main/java/pl/lambada/songsync/util/ext/ContextExt.kt
@@ -11,5 +11,5 @@ fun Context.getVersion(): String {
     } else {
         @Suppress("deprecation") packageManager.getPackageInfo(packageName, 0)
     }
-    return pInfo.versionName
+    return pInfo.versionName.toString()
 }

--- a/app/src/main/java/pl/lambada/songsync/util/ui/AnimationSpecs.kt
+++ b/app/src/main/java/pl/lambada/songsync/util/ui/AnimationSpecs.kt
@@ -4,11 +4,15 @@ import android.graphics.Path
 import android.view.animation.PathInterpolator
 import androidx.compose.animation.BoundsTransform
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.ArcMode
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.ExperimentalAnimationSpecApi
+import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.tween
 import pl.lambada.songsync.util.ui.MotionConstants.DURATION
 import pl.lambada.songsync.util.ui.MotionConstants.DURATION_ENTER
+import pl.lambada.songsync.util.ui.MotionConstants.DURATION_ENTER_SHORT
 import pl.lambada.songsync.util.ui.MotionConstants.DURATION_EXIT
 import pl.lambada.songsync.util.ui.MotionConstants.DURATION_EXIT_SHORT
 
@@ -56,5 +60,14 @@ fun <T> tweenExit(
 @OptIn(ExperimentalSharedTransitionApi::class)
 val DefaultBoundsTransform = BoundsTransform { _, _ ->
     tween(easing = EmphasizedEasing, durationMillis = DURATION)
+}
+
+@OptIn(ExperimentalAnimationSpecApi::class, ExperimentalSharedTransitionApi::class)
+val SearchFABBoundsTransform = BoundsTransform { initialBounds, targetBounds ->
+    keyframes {
+        durationMillis = DURATION_ENTER_SHORT
+        initialBounds at 0 using ArcMode.ArcBelow using MotionEasingStandard
+        targetBounds at DURATION_ENTER_SHORT using ArcMode.ArcAbove using MotionEasingStandard
+    }
 }
 

--- a/app/src/main/java/pl/lambada/songsync/util/ui/AnimationSpecs.kt
+++ b/app/src/main/java/pl/lambada/songsync/util/ui/AnimationSpecs.kt
@@ -1,0 +1,60 @@
+package pl.lambada.songsync.util.ui
+
+import android.graphics.Path
+import android.view.animation.PathInterpolator
+import androidx.compose.animation.BoundsTransform
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.tween
+import pl.lambada.songsync.util.ui.MotionConstants.DURATION
+import pl.lambada.songsync.util.ui.MotionConstants.DURATION_ENTER
+import pl.lambada.songsync.util.ui.MotionConstants.DURATION_EXIT
+import pl.lambada.songsync.util.ui.MotionConstants.DURATION_EXIT_SHORT
+
+fun PathInterpolator.toEasing(): Easing {
+    return Easing { f -> this.getInterpolation(f) }
+}
+
+private val path = Path().apply {
+    moveTo(0f, 0f)
+    cubicTo(0.05F, 0F, 0.133333F, 0.06F, 0.166666F, 0.4F)
+    cubicTo(0.208333F, 0.82F, 0.25F, 1F, 1F, 1F)
+}
+
+val EmphasizedPathInterpolator = PathInterpolator(path)
+val EmphasizedEasing = EmphasizedPathInterpolator.toEasing()
+
+val EmphasizeEasingVariant = CubicBezierEasing(.2f, 0f, 0f, 1f)
+val EmphasizedDecelerate = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
+val EmphasizedAccelerate = CubicBezierEasing(0.3f, 0f, 1f, 1f)
+val EmphasizedDecelerateEasing = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
+val EmphasizedAccelerateEasing = CubicBezierEasing(0.3f, 0f, 0.8f, 0.15f)
+
+val StandardDecelerate = CubicBezierEasing(.0f, .0f, 0f, 1f)
+val MotionEasingStandard = CubicBezierEasing(0.4F, 0.0F, 0.2F, 1F)
+
+val tweenSpec = tween<Float>(durationMillis = DURATION_ENTER, easing = EmphasizedEasing)
+
+fun <T> tweenEnter(
+    delayMillis: Int = DURATION_EXIT,
+    durationMillis: Int = DURATION_ENTER
+) =
+    tween<T>(
+        delayMillis = delayMillis,
+        durationMillis = durationMillis,
+        easing = EmphasizedDecelerateEasing
+    )
+
+fun <T> tweenExit(
+    durationMillis: Int = DURATION_EXIT_SHORT,
+) = tween<T>(
+    durationMillis = durationMillis,
+    easing = EmphasizedAccelerateEasing
+)
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+val DefaultBoundsTransform = BoundsTransform { _, _ ->
+    tween(easing = EmphasizedEasing, durationMillis = DURATION)
+}
+

--- a/app/src/main/java/pl/lambada/songsync/util/ui/MaterialSharedAxis.kt
+++ b/app/src/main/java/pl/lambada/songsync/util/ui/MaterialSharedAxis.kt
@@ -1,0 +1,240 @@
+package pl.lambada.songsync.util.ui
+
+/*
+ * Copyright 2021 SOUP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+
+
+/**
+ * Returns the provided [Dp] as an [Int] value by the [LocalDensity].
+ *
+ * @param slideDistance Value to the slide distance dimension, 30dp by default.
+ */
+@Composable
+fun rememberSlideDistance(
+    slideDistance: Dp = MotionConstants.DefaultSlideDistance,
+): Int {
+    val density = LocalDensity.current
+    return remember(density, slideDistance) {
+        with(density) { slideDistance.roundToPx() }
+    }
+}
+
+private const val ProgressThreshold = 0.35f
+
+private val Int.ForOutgoing: Int
+    get() = (this * ProgressThreshold).toInt()
+
+private val Int.ForIncoming: Int
+    get() = this - this.ForOutgoing
+
+/**
+ * [materialSharedAxisX] allows to switch a layout with shared X-axis transition.
+ *
+ */
+fun materialSharedAxisX(
+    initialOffsetX: (fullWidth: Int) -> Int,
+    targetOffsetX: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): ContentTransform = materialSharedAxisXIn(
+    initialOffsetX = initialOffsetX,
+    durationMillis = durationMillis
+) togetherWith materialSharedAxisXOut(
+    targetOffsetX = targetOffsetX,
+    durationMillis = durationMillis
+)
+
+/**
+ * [materialSharedAxisXIn] allows to switch a layout with shared X-axis enter transition.
+ */
+fun materialSharedAxisXIn(
+    initialOffsetX: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): EnterTransition = slideInHorizontally(
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = FastOutSlowInEasing
+    ),
+    initialOffsetX = initialOffsetX
+) + fadeIn(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForIncoming,
+        delayMillis = durationMillis.ForOutgoing,
+        easing = LinearOutSlowInEasing
+    )
+)
+
+/**
+ * [materialSharedAxisXOut] allows to switch a layout with shared X-axis exit transition.
+ *
+ */
+fun materialSharedAxisXOut(
+    targetOffsetX: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): ExitTransition = slideOutHorizontally(
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = FastOutSlowInEasing
+    ),
+    targetOffsetX = targetOffsetX
+) + fadeOut(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForOutgoing,
+        delayMillis = 0,
+        easing = FastOutLinearInEasing
+    )
+)
+
+/**
+ * [materialSharedAxisY] allows to switch a layout with shared Y-axis transition.
+ *
+ */
+fun materialSharedAxisY(
+    initialOffsetX: (fullWidth: Int) -> Int,
+    targetOffsetY: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): ContentTransform = materialSharedAxisYIn(
+    initialOffsetY = initialOffsetX,
+    durationMillis = durationMillis
+) togetherWith materialSharedAxisYOut(
+    targetOffsetY = targetOffsetY,
+    durationMillis = durationMillis
+)
+
+/**
+ * [materialSharedAxisYIn] allows to switch a layout with shared Y-axis enter transition.
+ *
+ */
+fun materialSharedAxisYIn(
+    initialOffsetY: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): EnterTransition = slideInVertically(
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = FastOutSlowInEasing
+    ),
+    initialOffsetY = initialOffsetY
+) + fadeIn(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForIncoming,
+        delayMillis = durationMillis.ForOutgoing,
+        easing = LinearOutSlowInEasing
+    )
+)
+
+/**
+ * [materialSharedAxisYOut] allows to switch a layout with shared Y-axis exit transition.
+ *
+ */
+fun materialSharedAxisYOut(
+    targetOffsetY: (fullWidth: Int) -> Int,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): ExitTransition = slideOutVertically(
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = FastOutSlowInEasing
+    ),
+    targetOffsetY = targetOffsetY
+) + fadeOut(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForOutgoing,
+        delayMillis = 0,
+        easing = FastOutLinearInEasing
+    )
+)
+
+/**
+ * [materialSharedAxisZ] allows to switch a layout with shared Z-axis transition.
+ *
+ * @param forward whether the direction of the animation is forward.
+ * @param durationMillis the duration of transition.
+ */
+fun materialSharedAxisZ(
+    forward: Boolean,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): ContentTransform = materialSharedAxisZIn(
+    forward = forward,
+    durationMillis = durationMillis
+) togetherWith materialSharedAxisZOut(
+    forward = forward,
+    durationMillis = durationMillis
+)
+
+/**
+ * [materialSharedAxisZIn] allows to switch a layout with shared Z-axis enter transition.
+ *
+ * @param forward whether the direction of the animation is forward.
+ * @param durationMillis the duration of the enter transition.
+ */
+fun materialSharedAxisZIn(
+    forward: Boolean,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): EnterTransition = fadeIn(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForIncoming,
+        delayMillis = durationMillis.ForOutgoing,
+        easing = LinearOutSlowInEasing
+    )
+) + scaleIn(
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = FastOutSlowInEasing
+    ),
+    initialScale = if (forward) 0.8f else 1.1f
+)
+
+/**
+ * [materialSharedAxisZOut] allows to switch a layout with shared Z-axis exit transition.
+ *
+ * @param forward whether the direction of the animation is forward.
+ * @param durationMillis the duration of the exit transition.
+ */
+fun materialSharedAxisZOut(
+    forward: Boolean,
+    durationMillis: Int = MotionConstants.DefaultMotionDuration,
+): ExitTransition = fadeOut(
+    animationSpec = tween(
+        durationMillis = durationMillis.ForOutgoing,
+        delayMillis = 0,
+        easing = FastOutLinearInEasing
+    )
+) + scaleOut(
+    animationSpec = tween(
+        durationMillis = durationMillis,
+        easing = FastOutSlowInEasing
+    ),
+    targetScale = if (forward) 1.1f else 0.8f
+)

--- a/app/src/main/java/pl/lambada/songsync/util/ui/MotionConstants.kt
+++ b/app/src/main/java/pl/lambada/songsync/util/ui/MotionConstants.kt
@@ -1,0 +1,36 @@
+package pl.lambada.songsync.util.ui
+
+/*
+ * Copyright 2021 SOUP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+object MotionConstants {
+    const val DefaultMotionDuration: Int = 300
+    const val DefaultFadeInDuration: Int = 150
+    const val DefaultFadeOutDuration: Int = 75
+    val DefaultSlideDistance: Dp = 30.dp
+
+    const val DURATION = 600
+    const val DURATION_ENTER = 400
+    const val DURATION_ENTER_SHORT = 300
+    const val DURATION_EXIT = 200
+    const val DURATION_EXIT_SHORT = 100
+
+    const val InitialOffset = 0.10f
+}

--- a/app/src/main/res/values-es/plurals.xml
+++ b/app/src/main/res/values-es/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <plurals name="this_will_download_lyrics_for_all_songs" tools:ignore="MissingQuantity">
-        <item quantity="other">Esto descargará las letras de %1$d canciones. Las letras existentes de las canciones se sobrescribirán con las nuevas. Esto puede ser menos preciso que descargar las letras una por una. Estás seguro de que quieres continuar?</item>
-        <item quantity="one">Esto descargará la letra de una canción. Las letras existentes de las canciones se sobrescribirán con las nuevas. Esto puede ser menos preciso que descargar las letras una por una. Estás seguro de que quieres continuar?</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,4 +146,9 @@
     <string name="translation">Translation</string>
     <string name="help_us_translate">Help us translate the app to your language!</string>
     <string name="translation_website">Open Weblate</string>
+    <string name="showing_lyrics_for">Showing lyrics for</string>
+    <string name="by">by</string>
+    <string name="accept">Accept</string>
+    <string name="song_lyrics">Song lyrics</string>
+    <string name="lyrics_subtitle">"Retrieved song lyrics that will be sent to the application "</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,4 +152,5 @@
     <string name="song_lyrics">Song lyrics</string>
     <string name="lyrics_subtitle">"Retrieved song lyrics that will be sent to the application "</string>
     <string name="song_name_not_provided">The song name has not been provided</string>
+    <string name="unknown_error_occurred">An unknown error occurred</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,4 +151,5 @@
     <string name="accept">Accept</string>
     <string name="song_lyrics">Song lyrics</string>
     <string name="lyrics_subtitle">"Retrieved song lyrics that will be sent to the application "</string>
+    <string name="song_name_not_provided">The song name has not been provided</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,4 +2,13 @@
 <resources>
 
     <style name="Theme.SongSync" parent="android:Theme.Material.Light.NoActionBar" />
+
+    <style name="Theme.SongSync.SharingActivity" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowContentOverlay">@null</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,7 +3,7 @@
 
     <style name="Theme.SongSync" parent="android:Theme.Material.Light.NoActionBar" />
 
-    <style name="Theme.SongSync.SharingActivity" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.SongSync.SharingActivity" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowIsFloating">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>


### PR DESCRIPTION
Added a new activity for quick lyrics search that can be launched from an intent. The activity fetches lyrics for a given song and artist using the LyricsProviderService. The user can then send the lyrics back to the calling app.

This feature is useful for quickly sharing lyrics without having to open the main app.