### PR TITLE
Add Musixmatch Lyrics Translation Support

### DIFF
--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/LyricsProviderService.kt
@@ -131,4 +131,8 @@ class LyricsProviderService {
             )
         }
     }
+
+    suspend fun getLyricsInLanguage(songId: Long, language: String): String? {
+        return MusixmatchAPI().getLyricsInLanguage(songId, language)
+    }
 }

--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
@@ -38,7 +38,7 @@ class MusixmatchAPI {
             throw EmptyQueryException()
 
         val response = client.get(
-            "$baseURL/full?artist=$artistName&track=$songName"
+            "$baseURL/v2/full?artist=$artistName&track=$songName"
         )
         val responseBody = response.bodyAsText(Charsets.UTF_8)
 

--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
@@ -69,4 +69,64 @@ class MusixmatchAPI {
     fun getLyrics(songInfo: SongInfo?, preferUnsynced: Boolean = true): String? {
         return songInfo?.syncedLyrics ?: if (preferUnsynced) songInfo?.unsyncedLyrics else null
     }
+
+    /**
+     * Gets the display name for a language code.
+     * @param languageCode The ISO language code.
+     * @return The display name of the language.
+     */
+    fun getLanguageDisplayName(languageCode: String): String {
+        return when (languageCode) {
+            "en" -> "English"
+            "es" -> "Español"
+            "fr" -> "Français"
+            "de" -> "Deutsch"
+            "it" -> "Italiano"
+            "pt" -> "Português"
+            "ru" -> "Русский"
+            "ja" -> "日本語"
+            "ko" -> "한국어"
+            "zh" -> "中文"
+            "ar" -> "العربية"
+            "hi" -> "हिन्दी"
+            "tr" -> "Türkçe"
+            "pl" -> "Polski"
+            "nl" -> "Nederlands"
+            "sv" -> "Svenska"
+            "da" -> "Dansk"
+            "no" -> "Norsk"
+            "cs" -> "Čeština"
+            "sk" -> "Slovenčina"
+            "hu" -> "Magyar"
+            "ro" -> "Română"
+            "bg" -> "Български"
+            "hr" -> "Hrvatski"
+            "sr" -> "Српски"
+            "sl" -> "Slovenščina"
+            "et" -> "Eesti"
+            "lv" -> "Latviešu"
+            "lt" -> "Lietuvių"
+            "uk" -> "Українська"
+            "he" -> "עברית"
+            "th" -> "ไทย"
+            "vi" -> "Tiếng Việt"
+            "id" -> "Bahasa Indonesia"
+            "ms" -> "Bahasa Melayu"
+            "ta" -> "தமிழ்"
+            "bn" -> "বাংলা"
+            "fa" -> "فارسی"
+            "uz" -> "O'zbek"
+            "ky" -> "Кыргызча"
+            "mn" -> "Монгол"
+            "ka" -> "ქართული"
+            "az" -> "Azərbaycan"
+            "af" -> "Afrikaans"
+            "is" -> "Íslenska"
+            "mk" -> "Македонски"
+            "bs" -> "Bosanski"
+            "fi" -> "Finnish"
+            "nb" -> "Norsk Bokmål"
+            else -> languageCode.uppercase()
+        }
+    }
 }

--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
@@ -61,6 +61,35 @@ class MusixmatchAPI {
     }
 
     /**
+     * Gets lyrics in a specific language for a song.
+     * @param songId The Musixmatch song ID.
+     * @param language The language code (e.g., "es", "fr", "de").
+     * @param preferSynced Whether to prefer synced lyrics over unsynced.
+     * @return The lyrics in the requested language or null if not available.
+     */
+    suspend fun getLyricsInLanguage(
+        songId: Long,
+        language: String,
+        preferSynced: Boolean = true
+    ): String? {
+        val response = client.get(
+            "$baseURL/v2/full?id=$songId&lang=$language"
+        )
+        val responseBody = response.bodyAsText(Charsets.UTF_8)
+
+        if (response.status.value !in 200..299)
+            return null
+
+        val result = json.decodeFromString<MusixmatchSearchResponse>(responseBody)
+
+        return if (preferSynced && result.syncedLyrics != null) {
+            result.syncedLyrics.lyrics
+        } else {
+            result.unsyncedLyrics?.lyrics
+        }
+    }
+
+    /**
      * Returns the lyrics.
      * @param songInfo The SongInfo of the song from search results.
      * @param preferUnsynced Flag to prefer unsynced lyrics when synced lyrics are not available.

--- a/app/src/main/java/pl/lambada/songsync/domain/model/SongInfo.kt
+++ b/app/src/main/java/pl/lambada/songsync/domain/model/SongInfo.kt
@@ -37,4 +37,7 @@ data class SongInfo(
     var hasUnsyncedLyrics: Boolean? = null, // Musixmatch-only
     var syncedLyrics: String? = null, // Musixmatch-only
     var unsyncedLyrics: String? = null, // Musixmatch-only
+    var availableLanguages: List<String> = emptyList(), // Musixmatch-only
+    var originalLanguage: String? = null, // Musixmatch-only
+    var currentLanguage: String? = null, // Musixmatch-only
 ) : Parcelable

--- a/app/src/main/java/pl/lambada/songsync/domain/model/lyrics_providers/others/Musixmatch.kt
+++ b/app/src/main/java/pl/lambada/songsync/domain/model/lyrics_providers/others/Musixmatch.kt
@@ -15,6 +15,8 @@ data class MusixmatchSearchResponse(
     val albumId: Long,
     val hasSyncedLyrics: Boolean,
     val hasUnsyncedLyrics: Boolean,
+    val availableLanguages: List<String> = emptyList(),
+    val originalLanguage: String? = null,
     val syncedLyrics: SyncedLyricsResponse? = null,
     val unsyncedLyrics: UnsyncedLyricsResponse? = null
 )

--- a/app/src/main/java/pl/lambada/songsync/ui/screens/lyricsFetch/LyricsFetchScreen.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/screens/lyricsFetch/LyricsFetchScreen.kt
@@ -212,6 +212,9 @@ fun SharedTransitionScope.LyricsFetchScreen(
                                 context.getString(R.string.lyrics_copied_to_clipboard),
                             )
                         },
+                        onLanguageSelected = { songId, language ->
+                            viewModel.fetchLyricsInLanguage(songId, language)
+                        },
                         openUri = uriHandler::openUri,
                         lyricsFetchState = viewModel.lyricsFetchState,
                         animatedVisibilityScope = animatedVisibilityScope,

--- a/app/src/main/java/pl/lambada/songsync/ui/screens/lyricsFetch/components/LanguageSelector.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/screens/lyricsFetch/components/LanguageSelector.kt
@@ -1,0 +1,103 @@
+package pl.lambada.songsync.ui.screens.lyricsFetch.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import pl.lambada.songsync.R
+import pl.lambada.songsync.data.remote.lyrics_providers.others.MusixmatchAPI
+
+@Composable
+fun LanguageSelector(
+    availableLanguages: List<String>,
+    currentLanguage: String?,
+    originalLanguage: String?,
+    onLanguageSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    musixmatchAPI: MusixmatchAPI = MusixmatchAPI()
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    if (availableLanguages.isEmpty()) return
+
+    OutlinedCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { expanded = true },
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Language,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = currentLanguage?.let {
+                        musixmatchAPI.getLanguageDisplayName(it)
+                    } ?: stringResource(R.string.select_language)
+                )
+            }
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            // Original language first
+            originalLanguage?.let { origLang ->
+                DropdownMenuItem(
+                    text = {
+                        Text("${musixmatchAPI.getLanguageDisplayName(origLang)} (Original)")
+                    },
+                    onClick = {
+                        onLanguageSelected(origLang)
+                        expanded = false
+                    }
+                )
+            }
+
+            // Other available languages
+            availableLanguages.filter { it != originalLanguage }.forEach { language ->
+                DropdownMenuItem(
+                    text = {
+                        Text(musixmatchAPI.getLanguageDisplayName(language))
+                    },
+                    onClick = {
+                        onLanguageSelected(language)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/pl/lambada/songsync/ui/screens/lyricsFetch/components/LyricsSuccessContent.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/screens/lyricsFetch/components/LyricsSuccessContent.kt
@@ -61,9 +61,23 @@ fun LyricsSuccessContent(
     onSetOffset: (Int) -> Unit,
     onSaveLyrics: () -> Unit,
     onEmbedLyrics: () -> Unit,
-    onCopyLyrics: () -> Unit
+    onCopyLyrics: () -> Unit,
+    onLanguageSelected: (String) -> Unit = {}
+    availableLanguages: List<String> = emptyList(),
+    currentLanguage: String? = null,
+    originalLanguage: String? = null,
 ) {
     Column {
+        if (availableLanguages.isNotEmpty()) {
+            LanguageSelector(
+                availableLanguages = availableLanguages,
+                currentLanguage = currentLanguage,
+                originalLanguage = originalLanguage,
+                onLanguageSelected = onLanguageSelected,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+        
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/pl/lambada/songsync/ui/screens/lyricsFetch/components/SuccessContent.kt
+++ b/app/src/main/java/pl/lambada/songsync/ui/screens/lyricsFetch/components/SuccessContent.kt
@@ -40,6 +40,7 @@ fun SharedTransitionScope.SuccessContent(
     onSaveLyrics: (String) -> Unit,
     onEmbedLyrics: (String) -> Unit,
     onCopyLyrics: (String) -> Unit,
+    onLanguageSelected: (Long?, String) -> Unit = { _, _ -> },
     openUri: (String) -> Unit,
     lyricsFetchState: LyricsFetchState,
     animatedVisibilityScope: AnimatedVisibilityScope,
@@ -106,7 +107,13 @@ fun SharedTransitionScope.SuccessContent(
                     onSetOffset = onSetOffset,
                     onSaveLyrics = { onSaveLyrics(it.lyrics) },
                     onEmbedLyrics = { onEmbedLyrics(it.lyrics) },
-                    onCopyLyrics = { onCopyLyrics(it.lyrics) }
+                    onCopyLyrics = { onCopyLyrics(it.lyrics) },
+                    onLanguageSelected = { language ->
+                        onLanguageSelected(result.musixmatchID, language)
+                    }
+                    availableLanguages = result.availableLanguages,
+                    currentLanguage = result.currentLanguage,
+                    originalLanguage = result.originalLanguage,
                 )
 
                 is LyricsFetchState.Failed -> Text(stringResource(R.string.this_track_has_no_lyrics))


### PR DESCRIPTION
Adds support for displaying lyrics in different languages through Musixmatch API. Users can now select from available translations using a language selector dropdown.

Closes #142 