### PR TITLE
Update base URL to fetch spotify TOTP

### DIFF
--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/spotify/SpotifyAPI.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/spotify/SpotifyAPI.kt
@@ -60,7 +60,7 @@ class SpotifyAPI {
         if (totpGenerator != null) return
 
         try {
-            val response = client.get("https://github.com/Thereallo1026/spotify-secrets/blob/main/secrets/secretBytes.json?raw=true")
+            val response = client.get("https://raw.githubusercontent.com/xyloflake/spot-secrets-go/refs/heads/main/secrets/secretBytes.json")
             val responseBody = response.bodyAsText(Charsets.UTF_8)
             val secretDataList = json.decodeFromString<List<SecretData>>(responseBody)
             


### PR DESCRIPTION
The previous one was taken down, so I replaced it with a new one I found.

This change might fix #179.

Thanks to [xyloflake/spot-secrets-go](https://github.com/xyloflake/spot-secrets-go).