### PR TITLE
Musixmatch is back!

### DIFF
--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/MusixmatchAPI.kt
@@ -12,7 +12,7 @@ import pl.lambada.songsync.util.networking.Ktor.json
 import java.net.URLEncoder
 
 class MusixmatchAPI {
-    private val baseURL = "https://kerollosy.vercel.app"
+    private val baseURL = "http://158.180.60.95"
 
     /**
      * Searches for synced lyrics using the song name and artist name.


### PR DESCRIPTION
I moved the API from Vercel to a dedicated Oracle Cloud server. It’s way faster than before, and we don't have to worry about the free tier limits that were causing the outages.

I also added an optimized token-rotation algorithm. The cool part is it actually gets smarter and more efficient the more it's used, so the success rate will only go up from here.

Closes #207 and partially #204 