### PR TITLE
fix: decode HTML entities in Netease lyrics (#216)

### DIFF
--- a/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/NeteaseAPI.kt
+++ b/app/src/main/java/pl/lambada/songsync/data/remote/lyrics_providers/others/NeteaseAPI.kt
@@ -1,6 +1,7 @@
 package pl.lambada.songsync.data.remote.lyrics_providers.others
 
 import android.util.Log
+import androidx.core.text.HtmlCompat
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -117,6 +118,16 @@ class NeteaseAPI {
         if (includeRomanization && json.romalrc?.lyric?.isNotEmpty() == true)
             lyric += "\n\n" + json.romalrc.lyric
 
-        return lyric
+        return decodeHtmlEntities(lyric)
+    }
+
+    /**
+     * Decodes HTML entities in lyrics text (e.g. &auml; -> ä).
+     * Processes line-by-line to preserve LRC timestamp format.
+     */
+    private fun decodeHtmlEntities(text: String): String {
+        return text.lines().joinToString("\n") { line ->
+            HtmlCompat.fromHtml(line, HtmlCompat.FROM_HTML_MODE_LEGACY).toString().trim()
+        }
     }
 }


### PR DESCRIPTION
Fixes #216

## Problem
Lyrics fetched from the Netease provider sometimes contain HTML encoded
special characters (e.g. `&auml;` instead of `ä`, `&uuml;` instead of `ü`,
`&szlig;` instead of `ß`).

This was reported when viewing lyrics for the song "Kein Alkohol (Ist auch
keine Lösung)!" by Die Toten Hosen from Netease.

## Solution
Added HTML entity decoding to `NeteaseAPI.getSyncedLyrics()` using
`HtmlCompat.fromHtml()` from AndroidX Core (already a project dependency).

The decoding is applied **line-by-line** to preserve the LRC timestamp format
— since `Html.fromHtml()` treats newlines as whitespace (standard HTML
behavior), processing each line individually ensures timestamps like
`[00:15.00]` and line breaks remain intact.

## Changes
- Added `decodeHtmlEntities()` private helper in `NeteaseAPI`
- Applied decoding before returning lyrics from `getSyncedLyrics()`
- No new dependencies required (uses existing `androidx.core:core-ktx`)

## Testing
1. Switch lyrics provider to **Netease**
2. Search for "Kein Alkohol" by "Die Toten Hosen"
3. Verify that special characters like `ä`, `ü`, `ß` display correctly
